### PR TITLE
fix(Attachments): 修复组件插槽上传调用

### DIFF
--- a/apps/playground/components.d.ts
+++ b/apps/playground/components.d.ts
@@ -21,6 +21,7 @@ declare module 'vue' {
     ElProgress: typeof import('element-plus/es')['ElProgress']
     ElTabPane: typeof import('element-plus/es')['ElTabPane']
     ElTabs: typeof import('element-plus/es')['ElTabs']
+    ElUpload: typeof import('element-plus/es')['ElUpload']
     FilesCardDemo: typeof import('./src/components/FilesCardDemo.vue')['default']
     MentionSenderDemo: typeof import('./src/components/MentionSenderDemo.vue')['default']
     PromptsDemo: typeof import('./src/components/PromptsDemo.vue')['default']

--- a/packages/components/src/components/Attachments/index.vue
+++ b/packages/components/src/components/Attachments/index.vue
@@ -251,16 +251,19 @@ defineExpose({
     }"
   >
     <div v-if="!items.length && !props.hideUpload">
-      <slot name="empty-upload">
-        <el-upload
-          class="elx-attachments-upload-btn" v-bind="$attrs" :show-file-list="false"
-          @change="handleUploadChange" @success="handleUploadSuccess" @error="handleUploadError"
-        >
-          <el-icon class="uploader-icon">
-            <Plus />
-          </el-icon>
-        </el-upload>
-      </slot>
+      <el-upload
+        class="elx-attachments-upload-btn"
+        :class="{ 'elx-has-upload-slot': $slots['no-empty-upload'] }" v-bind="$attrs" :show-file-list="false"
+        @change="handleUploadChange" @success="handleUploadSuccess" @error="handleUploadError"
+      >
+        <template #trigger>
+          <slot name="empty-upload">
+            <el-icon class="uploader-icon">
+              <Plus />
+            </el-icon>
+          </slot>
+        </template>
+      </el-upload>
     </div>
 
     <div class="elx-attachments-background">
@@ -294,20 +297,22 @@ defineExpose({
         </slot>
 
         <div v-if="items.length && !_isOverLimit && !props.hideUpload" class="elx-attachments-upload-placeholder">
-          <slot name="no-empty-upload">
-            <el-upload
-              v-bind="$attrs" :show-file-list="false" :style="{
-                height: overflow === 'scrollY' && '',
-              }" class="elx-attachments-upload-btn" @change="handleUploadChange" @success="handleUploadSuccess"
-              @error="handleUploadError"
-            >
-              <template #trigger>
+          <el-upload
+            v-bind="$attrs" :show-file-list="false" :style="{
+              height: overflow === 'scrollY' && '',
+            }"
+            class="elx-attachments-upload-btn" :class="{ 'elx-has-upload-slot': $slots['no-empty-upload'] }"
+            @change="handleUploadChange" @success="handleUploadSuccess"
+            @error="handleUploadError"
+          >
+            <template #trigger>
+              <slot name="no-empty-upload">
                 <el-icon class="uploader-icon">
                   <Plus />
                 </el-icon>
-              </template>
-            </el-upload>
-          </slot>
+              </slot>
+            </template>
+          </el-upload>
         </div>
       </div>
     </div>
@@ -486,6 +491,9 @@ defineExpose({
 }
 
 :deep() {
+  .elx-has-upload-slot .el-upload{
+    border: none;
+  }
   .el-upload {
     border: 1px dashed var(--el-border-color);
     border-radius: 6px;


### PR DESCRIPTION
在使用Attachments组件时发现
#empty-upload和#no-empty-upload两个插槽无法调用上传问题，此pr作为修复，另外对修改后的样式做了调整

