### PR TITLE
fix: BubbleList 的 handleScroll 方法

### DIFF
--- a/packages/components/src/components/BubbleList/index.vue
+++ b/packages/components/src/components/BubbleList/index.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<BubbleListProps<T>>(), {
   },
   btnLoading: true,
   btnColor: '#409EFF',
-  btnIconSize: 24
+  btnIconSize: 24,
 })
 
 const emits = defineEmits(['complete'])
@@ -173,6 +173,12 @@ function handleScroll() {
     // 计算是否超过安全距离
     const distanceToBottom = scrollHeight - (scrollTop + clientHeight)
     showBackToBottom.value = props.showBackButton && distanceToBottom > props.backButtonThreshold
+
+    // 处理 lastScrollTop.value 安全距离(scrollHeight 在滚动过程中变小)
+    const maxScrollTop = scrollHeight - clientHeight
+    if (lastScrollTop.value > maxScrollTop) {
+      lastScrollTop.value = maxScrollTop
+    }
 
     // 判断是否距离底部小于阈值 (这里吸附值大一些会体验更好)
     const isCloseToBottom = scrollTop + clientHeight >= scrollHeight - 30


### PR DESCRIPTION
## 修复 BubbleList 的 handleScroll 方法
在对话过程中，如果当前块的总高度变小，会导致下图这里进行误判，误以为是用户进行了向上的滚动，而实际是总高度变小，未处理 `lastScrollTop.value` 的边界

![image](https://github.com/user-attachments/assets/48bd4a74-a38f-4862-b13d-aa28a7e3d633)
