### PR TITLE
fix: 修复 Thinking 组件展开图标显示不准确

### DIFF
--- a/packages/components/src/components/Thinking/index.vue
+++ b/packages/components/src/components/Thinking/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ThinkingProps, ThinkingStatus } from './types.d.ts'
-import { ArrowUpBold, CircleCloseFilled, Loading, Opportunity, SuccessFilled } from '@element-plus/icons-vue'
+import { ArrowDownBold, CircleCloseFilled, Loading, Opportunity, SuccessFilled } from '@element-plus/icons-vue'
 
 const props = withDefaults(defineProps<ThinkingProps>(), {
   content: '',
@@ -107,7 +107,7 @@ watch(() => props.status, (newVal) => {
         <span v-if="!props.disabled" class="arrow el-icon-center" :class="{ expanded: isExpanded }">
           <slot name="arrow">
             <el-icon class="el-icon-center">
-              <ArrowUpBold />
+              <ArrowDownBold />
             </el-icon>
           </slot>
         </span>


### PR DESCRIPTION
修复Thinking组件展开图标显示不准确问题，如图豆包与deepseek展开时箭头应该向上
![image](https://github.com/user-attachments/assets/fe5fb588-fd27-4597-a70d-37271b3fe70f)
![image](https://github.com/user-attachments/assets/c04d5ee0-4032-404c-bca0-26c8286adba6)
