### PR TITLE
refactor(core): 重构 Markdown 组件并添加高亮代码演示 只在高亮代码的demo展示插槽

### DIFF
--- a/packages/core/src/stories/Markdown/Markdown.stories.ts
+++ b/packages/core/src/stories/Markdown/Markdown.stories.ts
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
-// import type MarkdownSource from '../../components/Markdown';
 import {
   highlightMdContent,
   mathMdContent,
   mdContent,
   mermaidMdContent
 } from '@assets/mock';
+import HighlightCodeDemo from './highlight-code.vue';
 import Markdown from './index.vue';
 
 const meta = {
@@ -57,7 +57,16 @@ export const MarkdownDemo: Story = {
 export const highlightMdContentDemo: Story = {
   args: {
     markdown: highlightMdContent
-  } as Story['args']
+  },
+  render: args => ({
+    components: {
+      HighlightCodeDemo
+    },
+    setup() {
+      return { attrs: args };
+    },
+    template: `<HighlightCodeDemo v-bind="attrs"  />`
+  })
 };
 
 export const PieRenderDemo: Story = {

--- a/packages/core/src/stories/Markdown/highlight-code.vue
+++ b/packages/core/src/stories/Markdown/highlight-code.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { h } from 'vue';
+import {
+  MarkdownRenderer
+  // MarkdownRendererAsync
+} from '../../components/Markdown/index';
+import CodeHeader from './CodeHeader.vue';
+
+const props = defineProps<{
+  markdown: string;
+}>();
+const timer = ref();
+const index = ref(0);
+function start() {
+  timer.value = setInterval(() => {
+    index.value += 5;
+    if (index.value > props.markdown.length) {
+      clearInterval(timer.value);
+      index.value = props.markdown.length;
+    }
+  }, 100);
+}
+function pause() {
+  if (timer.value) {
+    clearInterval(timer.value);
+    timer.value = null;
+  }
+}
+
+const content = computed(() => {
+  return props.markdown.slice(0, index.value);
+});
+
+function redo() {
+  index.value = 0;
+  if (timer.value) {
+    clearInterval(timer.value);
+    timer.value = null;
+  }
+  start();
+}
+onMounted(() => {
+  start();
+});
+</script>
+
+<template>
+  <el-button @click="start"> 开始 </el-button>
+  <el-button @click="pause"> 暂停 </el-button>
+  <el-button @click="redo"> 重新开始 </el-button>
+  <div class="component-container">
+    <h4>默认插槽</h4>
+    <MarkdownRenderer v-bind="$attrs" :markdown="content" />
+    <h4>全部函数式自定义插槽 以及方法</h4>
+    <MarkdownRenderer
+      v-bind="$attrs"
+      :markdown="content"
+      :code-x-slot="{
+        codeHeaderLanguage(props: any) {
+          return h(
+            'span',
+            { onClick: (ev: MouseEvent) => props.toggleExpand(ev) },
+            '语言(可点击切换)'
+          );
+        },
+        codeHeaderControl(props: any) {
+          return h(
+            'span',
+            {},
+            {
+              default: () => [
+                h(
+                  'button',
+                  {
+                    onClick: () => {
+                      console.log('isDark', props.toggleTheme());
+                    }
+                  },
+                  '主题'
+                ),
+                h('span', {}, '&nbsp;|&nbsp;'),
+                h(
+                  'button',
+                  {
+                    onClick: () => {
+                      props.copyCode(props.renderLines);
+                    }
+                  },
+                  '复制'
+                )
+              ]
+            }
+          );
+        }
+      }"
+    />
+    <h4>组件插槽</h4>
+    <MarkdownRenderer
+      v-bind="$attrs"
+      :markdown="content"
+      :code-x-slot="{
+        codeHeaderLanguage: CodeHeader
+      }"
+    />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.component-container {
+  background-color: white;
+  padding: 12px;
+  border-radius: 15px;
+}
+</style>

--- a/packages/core/src/stories/Markdown/index.vue
+++ b/packages/core/src/stories/Markdown/index.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import { h } from 'vue';
 import {
   MarkdownRenderer
   // MarkdownRendererAsync
 } from '../../components/Markdown/index';
-import CodeHeader from './CodeHeader.vue';
 
 const props = defineProps<{
   markdown: string;
@@ -49,59 +47,7 @@ onMounted(() => {
   <el-button @click="pause"> 暂停 </el-button>
   <el-button @click="redo"> 重新开始 </el-button>
   <div class="component-container">
-    <h4>默认插槽</h4>
     <MarkdownRenderer v-bind="$attrs" :markdown="content" />
-    <h4>全部函数式自定义插槽 以及方法</h4>
-    <MarkdownRenderer
-      v-bind="$attrs"
-      :markdown="content"
-      :code-x-slot="{
-        codeHeaderLanguage(props: any) {
-          return h(
-            'span',
-            { onClick: (ev: MouseEvent) => props.toggleExpand(ev) },
-            '语言(可点击切换)'
-          );
-        },
-        codeHeaderControl(props: any) {
-          return h(
-            'span',
-            {},
-            {
-              default: () => [
-                h(
-                  'button',
-                  {
-                    onClick: () => {
-                      console.log('isDark', props.toggleTheme());
-                    }
-                  },
-                  '主题'
-                ),
-                h('span', {}, '&nbsp;|&nbsp;'),
-                h(
-                  'button',
-                  {
-                    onClick: () => {
-                      props.copyCode(props.renderLines);
-                    }
-                  },
-                  '复制'
-                )
-              ]
-            }
-          );
-        }
-      }"
-    />
-    <h4>组件插槽</h4>
-    <MarkdownRenderer
-      v-bind="$attrs"
-      :markdown="content"
-      :code-x-slot="{
-        codeHeaderLanguage: CodeHeader
-      }"
-    />
   </div>
 </template>
 


### PR DESCRIPTION
- 添加了 HighlightCodeDemo 组件用于高亮代码演示
- 简化了 Markdown 组件的模板结构
- 优化了 Markdown 组件的样式