### PR TITLE
refactor(XMarkdownCore): 优化代码块的样式和布局

### DIFF
--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/index.vue
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/index.vue
@@ -164,8 +164,8 @@ const codeClass = computed(() => `language-${props.raw?.language || 'text'}`);
     <code
       :class="codeClass"
       :style="{
-        display: 'flex',
-        flexDirection: 'column'
+        display: 'block',
+        overflowX: 'auto'
       }"
       v-bind="codeAttrs"
     >

--- a/packages/core/src/components/XMarkdownCore/style/shiki.scss
+++ b/packages/core/src/components/XMarkdownCore/style/shiki.scss
@@ -248,11 +248,20 @@ body.dark .shiki span {
       flex: 1;
       box-sizing: border-box;
       width: 100%;
-      overflow: auto;
       height: 0;
       overflow: hidden;
-      span {
-        display: inline-block;
+
+      & > span {
+        width: max-content;
+        display: block;
+        .line {
+          width: max-content;
+          display: inline-block;
+          white-space: pre;
+          span {
+            display: inline-block;
+          }
+        }
       }
 
       &::-webkit-scrollbar {


### PR DESCRIPTION
- 调整代码块的显示方式为 block，允许水平滚动
- 重构 shiki.scss 中的代码样式，优化代码行的显示和滚动
- 移除冗余的 span 标签，简化代码结构