### PR TITLE
docs: 去除控制台 sass 编译警告

### DIFF
--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -73,5 +73,13 @@ export default defineConfig({
       //   replacement: path.resolve(baseUrl, 'packages/icons/src'),
       // },
     ]
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // 去除控制台 sass 编译警告
+        silenceDeprecations: ['legacy-js-api']
+      }
+    }
   }
 });


### PR DESCRIPTION
### 在本地开发是切换到组件模块会出现如下编译警告！
<img width="917" height="400" alt="image" src="https://github.com/user-attachments/assets/541e12b4-ae00-4bfb-9d6c-7b3fe80e6b50" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated SCSS preprocessor settings to suppress certain deprecation warnings during documentation site builds.
  * Improved stability of bubble list interactions by enhancing internal handling of scroll functions with added safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->