### PR TITLE
docs: 设置 ul 的 list-style

### DIFF
--- a/apps/docs/.vitepress/theme/style.css
+++ b/apps/docs/.vitepress/theme/style.css
@@ -133,4 +133,7 @@
   .vp-doc h3 {
     margin: 24px 0 12px;
   }
+  .vp-doc ul {
+    list-style: none;
+  }
 }


### PR DESCRIPTION
### 一些组件的 ul 的 list-style 被 VitePress 的样式覆盖
<img width="1505" height="709" alt="image" src="https://github.com/user-attachments/assets/e9707be4-17f7-45db-b141-eab8c1c2403b" />
