### PR TITLE
fix(BubbleList):  滚动过程的滚动距离计算

### DIFF
--- a/packages/core/src/components/BubbleList/index.vue
+++ b/packages/core/src/components/BubbleList/index.vue
@@ -175,6 +175,12 @@ function handleScroll() {
     showBackToBottom.value =
       props.showBackButton && distanceToBottom > props.backButtonThreshold;
 
+    // 处理 lastScrollTop.value 安全距离(scrollHeight 在滚动过程中变小)
+    const maxScrollTop = scrollHeight - clientHeight;
+    if (lastScrollTop.value > maxScrollTop) {
+      lastScrollTop.value = maxScrollTop;
+    }
+
     // 判断是否距离底部小于阈值 (这里吸附值大一些会体验更好)
     const isCloseToBottom = scrollTop + clientHeight >= scrollHeight - 30;
     // 判断用户是否向上滚动


### PR DESCRIPTION
### 修复 BubbleList 的滚动过程的最后滚动距离计算
> 在对话过程中，如果当前块的总高度变小，会导致下图这里进行误判，误以为是用户进行了向上的滚动，而实际是总高度变小，未处理 lastScrollTop.value 的边界
<img width="931" height="319" alt="image" src="https://github.com/user-attachments/assets/6db2761b-50b1-4483-acf7-a0ed31017f44" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll handling to prevent issues when the scrollable area shrinks, ensuring smoother and more reliable scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->