### PR TITLE
perf(Thinking): 优化思考组件展开收缩图标

### DIFF
--- a/packages/core/src/components/Thinking/index.vue
+++ b/packages/core/src/components/Thinking/index.vue
@@ -5,7 +5,7 @@ import type {
   ThinkingStatus
 } from './types.d.ts';
 import {
-  ArrowUpBold,
+  ArrowDownBold,
   CircleCloseFilled,
   Loading,
   Opportunity,
@@ -40,8 +40,7 @@ watch(
 
 // 处理展开/收起
 function changeExpand() {
-  if (props.disabled)
-    return;
+  if (props.disabled) return;
   isExpanded.value = !isExpanded.value;
   emit('change', { value: isExpanded.value, status: props.status });
   emit('update:modelValue', isExpanded.value);
@@ -127,7 +126,7 @@ watch(
         >
           <slot name="arrow">
             <el-icon class="el-icon-center">
-              <ArrowUpBold />
+              <ArrowDownBold />
             </el-icon>
           </slot>
         </span>


### PR DESCRIPTION
### 优化 Thinking 组件展开收缩图标显示不够准确问题，如图豆包与deepseek展开时箭头应该向上

- 豆包
<img width="926" height="506" alt="2aee8316-9164-4fbc-ac73-f39bf58286e6" src="https://github.com/user-attachments/assets/8656677a-18d5-40a3-a182-8d4f0ced6399" />

- deepseek
<img width="941" height="646" alt="image" src="https://github.com/user-attachments/assets/f92c5011-0ced-4f48-a16e-3a82c1e21907" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the trigger button icon from an upward arrow to a downward arrow for improved clarity.
  * Minor formatting adjustments for code consistency (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->