### PR TITLE
docs:输入框新增 `cmdOrCtrlEnter` 及 `altEnter` 演示

### DIFF
--- a/apps/docs/components/mentionSender/demos/submit-type.vue
+++ b/apps/docs/components/mentionSender/demos/submit-type.vue
@@ -41,6 +41,12 @@ function handleSubmit(value: string) {
       <el-radio-button value="shiftEnter">
         shiftEnter
       </el-radio-button>
+      <el-radio-button value="cmdOrCtrlEnter">
+        cmdOrCtrlEnter
+      </el-radio-button>
+      <el-radio-button value="altEnter">
+        altEnter
+      </el-radio-button>
     </el-radio-group>
     <MentionSender v-model="senderValue" :submit-type="activeName" :loading="senderLoading" @submit="handleSubmit" />
   </div>

--- a/apps/docs/components/sender/demos/submit-type.vue
+++ b/apps/docs/components/sender/demos/submit-type.vue
@@ -41,6 +41,12 @@ function handleSubmit(value: string) {
       <el-radio-button value="shiftEnter">
         shiftEnter
       </el-radio-button>
+      <el-radio-button value="cmdOrCtrlEnter">
+        shiftEnter
+      </el-radio-button>
+      <el-radio-button value="altEnter">
+        shiftEnter
+      </el-radio-button>
     </el-radio-group>
     <Sender v-model="senderValue" :submit-type="activeName" :loading="senderLoading" @submit="handleSubmit" />
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new submission mode options: "Cmd/Ctrl+Enter" and "Alt+Enter" to the submit type selection in the relevant components. Users can now choose these additional key combinations for submitting content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->