### PR TITLE
新增cdn资源加载

### DIFF
--- a/packages/core/.storybook/preview.ts
+++ b/packages/core/.storybook/preview.ts
@@ -1,39 +1,6 @@
 import type { Preview } from '@storybook/vue3';
 import { themes } from '@storybook/theming';
 
-/**
- * 加载 CDN 资源的工具函数
- * @param url CDN 资源链接
- * @param type 资源类型 'css' | 'js'
- */
-function loadCdnResource(url: string, type: 'css' | 'js') {
-  if (type === 'css') {
-    // 加载 CSS 资源
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = url;
-    document.head.appendChild(link);
-  } else if (type === 'js') {
-    // 加载 JS 资源
-    const script = document.createElement('script');
-    script.src = url;
-    document.head.appendChild(script);
-  }
-}
-
-// 配置需要加载的 CDN 资源
-const cdnResources = [
-  {
-    url: 'https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css',
-    type: 'css'
-  }
-];
-
-// 加载 CDN 资源
-cdnResources.forEach(resource => {
-  loadCdnResource(resource.url, resource.type as 'css' | 'js');
-});
-
 const preview: Preview = {
   parameters: {
     controls: {

--- a/packages/core/src/components/ConfigProvider/constants.ts
+++ b/packages/core/src/components/ConfigProvider/constants.ts
@@ -11,8 +11,18 @@ export const DEFAULT_MD_CONFIG: Options = {
   breaks: true
 };
 
-export const defaultAppConfig: ConfigProviderProps = {
+export const DEFAULT_APP_CONFIG: ConfigProviderProps = {
   mdPlugins: [],
-  md: new MarkdownIt(DEFAULT_MD_CONFIG)
-  // highlight: void 0,
+  md: new MarkdownIt(DEFAULT_MD_CONFIG),
+  cdnAssets: [
+    {
+      url: 'https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css'
+    }
+  ]
 };
+
+export const DEFAULT_CDN_ASSETS = [
+  {
+    url: 'https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css'
+  }
+];

--- a/packages/core/src/components/ConfigProvider/constants.ts
+++ b/packages/core/src/components/ConfigProvider/constants.ts
@@ -20,9 +20,3 @@ export const DEFAULT_APP_CONFIG: ConfigProviderProps = {
     }
   ]
 };
-
-export const DEFAULT_CDN_ASSETS = [
-  {
-    url: 'https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css'
-  }
-];

--- a/packages/core/src/components/ConfigProvider/hooks.ts
+++ b/packages/core/src/components/ConfigProvider/hooks.ts
@@ -1,5 +1,5 @@
-import { APP_CONFIG_PROVIDE_KEY, defaultAppConfig } from './constants';
+import { APP_CONFIG_PROVIDE_KEY, DEFAULT_APP_CONFIG } from './constants';
 
 export function useConfigProvider() {
-  return inject(APP_CONFIG_PROVIDE_KEY, defaultAppConfig);
+  return inject(APP_CONFIG_PROVIDE_KEY, DEFAULT_APP_CONFIG);
 }

--- a/packages/core/src/components/ConfigProvider/index.vue
+++ b/packages/core/src/components/ConfigProvider/index.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import type { ConfigProviderProps } from './types';
-import { APP_CONFIG_PROVIDE_KEY, defaultAppConfig } from './constants';
+import { loadCdn } from '../../utils/loadCdn';
+import { APP_CONFIG_PROVIDE_KEY, DEFAULT_APP_CONFIG } from './constants';
 
 const props = withDefaults(defineProps<ConfigProviderProps>(), {});
 
 provide<ConfigProviderProps>(APP_CONFIG_PROVIDE_KEY, {
-  md: props.md ?? defaultAppConfig.md,
-  mdPlugins: props.mdPlugins ?? defaultAppConfig.mdPlugins
-  // highlight: props.highlight ?? defaultAppConfig.highlight,
+  md: props.md ?? DEFAULT_APP_CONFIG.md,
+  mdPlugins: props.mdPlugins ?? DEFAULT_APP_CONFIG.mdPlugins
+});
+const cdnAssets = props.cdnAssets ?? DEFAULT_APP_CONFIG.cdnAssets;
+cdnAssets?.forEach(assets => {
+  loadCdn(assets);
 });
 </script>
 

--- a/packages/core/src/components/ConfigProvider/types.d.ts
+++ b/packages/core/src/components/ConfigProvider/types.d.ts
@@ -5,5 +5,9 @@ export type MarkdownItPlugin = (md: MarkdownIt) => void;
 export interface ConfigProviderProps {
   mdPlugins?: MarkdownItPlugin[];
   md?: MarkdownIt;
+  cdnAssets?: {
+    url: string;
+    attrs?: Record<string, string>;
+  }[];
   // highlight?: (code: string, language: string) => string;
 }

--- a/packages/core/src/stories/XMarkdown/index.vue
+++ b/packages/core/src/stories/XMarkdown/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ConfigProvider } from '../../components';
+
 const props = defineProps<{
   markdown: string;
 }>();
@@ -43,7 +45,9 @@ onMounted(() => {
   <el-button @click="redo"> 重新开始 </el-button>
   <div class="component-container">
     <!-- <MarkdownRenderer v-bind="$attrs" :markdown="content" /> -->
-    <XMarkdown v-bind="$attrs" :markdown="content" />
+    <ConfigProvider>
+      <XMarkdown v-bind="$attrs" :markdown="content" />
+    </ConfigProvider>
   </div>
 </template>
 

--- a/packages/core/src/utils/loadCdn.ts
+++ b/packages/core/src/utils/loadCdn.ts
@@ -1,0 +1,19 @@
+interface LoadCdnOptions {
+  url: string;
+  attrs?: Record<string, string>;
+}
+
+export function loadCdn(options: LoadCdnOptions): Promise<void> {
+  const { url, attrs = {} } = options;
+  return new Promise((resolve, reject) => {
+    const link = document.createElement('link');
+    link.href = url;
+    link.rel = 'stylesheet';
+    Object.entries(attrs).forEach(([key, value]) => {
+      link.setAttribute(key, value);
+    });
+    link.onload = () => resolve();
+    link.onerror = () => reject(new Error(`加载资源失败: ${url}`));
+    document.head.appendChild(link);
+  });
+}


### PR DESCRIPTION
- 移除多余hook文件
- 修改ConfigProvider文件常量名称
- 新增cdnAssets配置，默认加载katex样式
- 新版xmarkdown渲染公式需使用ConfigProvider组件包裹

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying external CDN assets (such as stylesheets) in the configuration, allowing dynamic loading of resources like KaTeX CSS.
  * Introduced a utility for loading external CDN assets with optional custom attributes.
* **Refactor**
  * Updated configuration naming conventions and structure for improved clarity.
  * Wrapped markdown rendering in a configuration provider for enhanced context management.
* **Bug Fixes**
  * Removed redundant CDN loading logic from the preview environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->