### PR TITLE
docs: 默认跳转英文页面

### DIFF
--- a/apps/docs/.vitepress/locales.mts
+++ b/apps/docs/.vitepress/locales.mts
@@ -5,7 +5,7 @@ const config = {
   root: {
     label: 'English',
     lang: 'en',
-    link: '/en/',  // 重要：设置英文版的链接前缀
+    link: '/en/', // 重要：设置英文版的链接前缀
     themeConfig: {
       // 英文导航 - 所有链接都加上 /en/ 前缀
       nav: [
@@ -20,7 +20,7 @@ const config = {
         { text: '🧭 Guide', link: '/en/guide/install' },
         { text: '🎨 Components', link: '/en/components/xmarkdown' },
       ],
-      
+
       // 英文侧边栏
       sidebar: {
         '/en/components/': [
@@ -81,7 +81,7 @@ const config = {
           },
         ],
       },
-      
+
       // 英文搜索配置
       search: {
         provider: 'local',
@@ -103,7 +103,7 @@ const config = {
           },
         },
       },
-      
+
       // 英文页脚
       docFooter: {
         prev: 'Previous',
@@ -119,7 +119,7 @@ const config = {
       },
     },
   },
-  
+
   zh: {
     label: '简体中文',
     lang: 'zh-CN',
@@ -138,7 +138,7 @@ const config = {
         { text: '🧭 指南', link: '/zh/guide/install' },
         { text: '🎨 组件', link: '/zh/components/xmarkdown' },
       ],
-      
+
       // 中文侧边栏
       sidebar: {
         '/zh/components/': [
@@ -199,7 +199,7 @@ const config = {
           },
         ],
       },
-      
+
       // 中文搜索配置
       search: {
         provider: 'local',
@@ -221,7 +221,7 @@ const config = {
           },
         },
       },
-      
+
       // 中文页脚
       docFooter: {
         prev: '上一篇',

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -9,7 +9,12 @@ markdownStyles: false
 ---
 
 <script setup>
-import MainPage from '/.vitepress/home/index.vue'
-</script>
+import { onBeforeMount } from 'vue'
+import { useRouter } from 'vitepress'
 
-<MainPage  />
+const router = useRouter()
+
+onBeforeMount(() => {
+  router.go('/en/')
+})
+</script>


### PR DESCRIPTION
onBeforeMount 钩子做根路径重定向，提早到最早时机跳转避免闪烁

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed trailing whitespace in locale configuration files for improved formatting.

* **New Features**
  * Updated documentation landing page to automatically redirect users to the English documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->