### PR TITLE
feat(core): 调整默认主题模式在对话中多次渲染时重置为亮色问题

### DIFF
--- a/packages/core/src/components/XMarkdownCore/shared/constants.ts
+++ b/packages/core/src/components/XMarkdownCore/shared/constants.ts
@@ -29,7 +29,7 @@ export const DEFAULT_PROPS = {
   sanitizeOptions: () => ({}),
   mermaidConfig: () => ({}),
   langs: () => [],
-  defaultThemeMode: 'light' as 'light' | 'dark',
+  defaultThemeMode: '' as 'light' | 'dark',
   themes: () => ({ ...shikiThemeDefault }),
   colorReplacements: () => ({}),
   needViewCodeBtn: true,

--- a/packages/core/src/stories/BubbleList/CustomSolt.vue
+++ b/packages/core/src/stories/BubbleList/CustomSolt.vue
@@ -5,6 +5,7 @@ import { avatar1, avatar2 } from '@assets/mock';
 import BubbleList from '@components/BubbleList/index.vue';
 import { DocumentCopy, Refresh, Search, Star } from '@element-plus/icons-vue';
 import { ElMessage } from 'element-plus';
+import { XMarkdown } from '../../components';
 
 const props = defineProps<Pick<BubbleListProps, 'list'>>();
 
@@ -20,7 +21,11 @@ function addMessage() {
   const isUser = !!(i % 2);
   const content = isUser
     ? 'Mock user content.'
-    : '欢迎使用 Element Plus X .'.repeat(5);
+    : `
+\`\`\`javascript
+console.log('Hello, world!');
+\`\`\`
+`.repeat(1);
   const placement = isUser ? 'end' : 'start';
   const typing = isUser ? false : { step: 2, suffix: '...' };
   const obj = {
@@ -113,7 +118,12 @@ onMounted(() => {
         <!-- 自定义 content -->
         <template #content="{ item }">
           <div class="content">
-            {{ item.content }}
+            <XMarkdown
+              v-if="item.role === 'ai'"
+              :markdown="item.content ?? ''"
+              default-them-mode="'dark'"
+            />
+            <span v-else>{{ item.content }} </span>
           </div>
         </template>
 


### PR DESCRIPTION
- 在气泡列表组件演示demo中添加 XMarkdown 组件，用于渲染 AI 角色的消息内容
- 优化气泡列表组件demo的头像显示，将 img 标签改为自定义组件
- 修改demo对话中 AI 角色消息内容，添加代码块示例

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI role messages are now displayed with rich Markdown formatting, enhancing readability and presentation.
  
* **Style**
  * AI messages are rendered with a default dark theme for improved visual distinction.

* **Refactor**
  * Adjusted how default theme mode is handled internally for Markdown rendering components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->