### PR TITLE
fix: 移除Mermaid组件中操作栏的用户选择禁用样式

### DIFF
--- a/packages/core/src/components/XMarkdownCore/components/Mermaid/MermaidToolbar.vue
+++ b/packages/core/src/components/XMarkdownCore/components/Mermaid/MermaidToolbar.vue
@@ -11,6 +11,12 @@ import {
 } from '@element-plus/icons-vue';
 import { computed, ref } from 'vue';
 
+interface MermaidToolbarInternalProps {
+  toolbarConfig?: MermaidToolbarConfig;
+  isSourceCodeMode?: boolean;
+  sourceCode?: string;
+}
+
 const props = withDefaults(defineProps<MermaidToolbarInternalProps>(), {
   toolbarConfig: () => ({}),
   isSourceCodeMode: false,
@@ -18,12 +24,6 @@ const props = withDefaults(defineProps<MermaidToolbarInternalProps>(), {
 });
 
 const emit = defineEmits<MermaidToolbarEmits>();
-
-interface MermaidToolbarInternalProps {
-  toolbarConfig?: MermaidToolbarConfig;
-  isSourceCodeMode?: boolean;
-  sourceCode?: string;
-}
 
 // 复制成功状态
 const isCopySuccess = ref(false);
@@ -317,7 +317,6 @@ function handleTabClickEvent(pane: TabClickEvent) {
   border-radius: 3px 3px 0 0;
   padding: 0 12px;
   pointer-events: auto;
-  user-select: none !important;
   position: relative;
   z-index: 10;
 

--- a/packages/core/src/components/XMarkdownCore/components/Mermaid/index.vue
+++ b/packages/core/src/components/XMarkdownCore/components/Mermaid/index.vue
@@ -193,10 +193,7 @@ const exposedMethods = computed(() => {
   <div
     ref="containerRef"
     :key="props.raw.key"
-    class="markdown-mermaid unselectable"
-    unselectable="on"
-    onselectstart="return false"
-    ondragstart="return false"
+    class="markdown-mermaid"
   >
     <!-- 工具栏 -->
     <Transition name="toolbar" appear>
@@ -238,9 +235,8 @@ const exposedMethods = computed(() => {
       @after-enter="onContentTransitionEnter"
     >
       <pre v-if="showSourceCode" key="source" class="mermaid-source-code">
-    {{ props.raw.content }}
-  </pre
-      >
+        {{ props.raw.content }}
+      </pre>
       <div v-else class="mermaid-content" v-html="svg" />
     </Transition>
   </div>

--- a/packages/core/src/components/XMarkdownCore/components/Mermaid/style.scss
+++ b/packages/core/src/components/XMarkdownCore/components/Mermaid/style.scss
@@ -7,10 +7,6 @@
   background-color: #f5f5f5;
   border-radius: 4px;
   overflow: hidden;
-  -webkit-user-select: none !important;
-  -moz-user-select: none !important;
-  -ms-user-select: none !important;
-  user-select: none !important;
   display: flex;
   flex-direction: column;
 
@@ -85,10 +81,7 @@
     min-height: 200px;
     // max-height: 80vh;
     cursor: grab;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+
     display: flex;
     align-items: center;
     justify-content: flex-start;
@@ -123,9 +116,6 @@
   }
 
   &.dragging {
-    -webkit-user-select: none;
-    user-select: none;
-
     .mermaid-content {
       cursor: grabbing;
     }


### PR DESCRIPTION
1. 移除Mermaid组件中操作栏的用户选择禁用样式(css)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styles to allow text selection within Mermaid toolbars and components by removing rules that previously disabled user selection.
  * Cleaned up related HTML attributes and classes that restricted text selection and drag events.
  * Improved code formatting for better readability in the source code display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->