### PR TITLE
feat(EditorSender):增加clear事件，增加暴露实例的submit方法

### DIFF
--- a/packages/core/src/components/EditorSender/index.vue
+++ b/packages/core/src/components/EditorSender/index.vue
@@ -178,6 +178,7 @@ function onClear(txt?: string) {
   chat.value!.clear(txt);
   // 将光标移动到末尾
   focusToEnd();
+  emits('clear');
 }
 // 点击内容区域聚焦输入框
 function onContentMouseDown() {
@@ -456,6 +457,7 @@ onBeforeUnmount(() => {
 
 /** 暴露方法 */
 defineExpose({
+  submit:onSubmit(),
   getCurrentValue,
   focusToStart,
   focusToEnd,

--- a/packages/core/src/components/EditorSender/types.d.ts
+++ b/packages/core/src/components/EditorSender/types.d.ts
@@ -74,6 +74,7 @@ export interface EditorSenderEmits {
   (e: 'submit', payload: SubmitResult): void;
   (e: 'change'): void;
   (e: 'cancel'): void;
+  (e: 'clear'): void;
   (e: 'showAtDialog'): void;
   (e: 'showSelectDialog', key: string, elm: HTMLElement): void;
   (e: 'showTagDialog', prefix: string): void;


### PR DESCRIPTION
EditorSender 组件
1、增加clear事件，方便监听clear后，清空上传的文件。
2、增加暴露实例的submit方法，方便直接通过函数调用提交方法。