### PR TITLE
fix:修复文档中安装指南的按需引入,描述有误bug  #309

### DIFF
--- a/apps/docs/zh/guide/install.md
+++ b/apps/docs/zh/guide/install.md
@@ -58,7 +58,7 @@ yarn add vue-element-plus-x --save
 1. **按需引入**
 
 ```vue
-<script>
+<script setup>
 import { BubbleList, Sender } from 'vue-element-plus-x';
 
 const list = [


### PR DESCRIPTION
修复文档中安装指南的按需引入,描述有误bug