### PR TITLE
feat(core): 新增打包时自动更新ChatArea依赖的最新版本

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,8 +70,8 @@
     "preview": "vite preview",
     "dev": "storybook dev -p 6006",
     "build:storybook": "storybook build",
-    "update:plugin": "npm i --save chatarea@latest",
-    "aeac": "rimraf src/index.ts && rimraf src/install.ts && esno .build/scripts/auto-export-all-components.js"
+    "aeac": "rimraf src/index.ts && rimraf src/install.ts && esno .build/scripts/auto-export-all-components.js",
+    "update:plugin": "npm i --save chatarea@latest"
   },
   "peerDependencies": {
     "vue": "^3.5.17"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,10 +66,11 @@
   "scripts": {
     "build:es": "vue-tsc -b && vite build",
     "build:umd": "vue-tsc -b && vite build --config vite.config.umd.ts",
-    "build": "rimraf dist && rimraf types && pnpm run aeac && pnpm run build:es && pnpm run build:umd",
+    "build": "rimraf dist && rimraf types && pnpm run update:plugin && pnpm run aeac && pnpm run build:es && pnpm run build:umd",
     "preview": "vite preview",
     "dev": "storybook dev -p 6006",
     "build:storybook": "storybook build",
+    "update:plugin": "npm i --save chatarea@latest",
     "aeac": "rimraf src/index.ts && rimraf src/install.ts && esno .build/scripts/auto-export-all-components.js"
   },
   "peerDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Build now runs a pre-step to automatically update the chat plugin before compilation, improving consistency and reducing build failures.
  * Added a command to manually trigger the plugin update when needed by developers.
  * Reordered the build sequence; release packaging and type outputs remain the same.
  * No runtime or feature changes are expected; end users should see no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->