### PR TITLE
feat: support latex 

### DIFF
--- a/packages/core/src/assets/mock.ts
+++ b/packages/core/src/assets/mock.ts
@@ -18,6 +18,10 @@ export const mdContent = `
 1. 欧拉公式：$e^{i\\pi} + 1 = 0$
 2. 二次方程求根公式：$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$
 3. 向量点积：$\\vec{a} \\cdot \\vec{b} = a_x b_x + a_y b_y + a_z b_z$
+### []包裹公式
+\\[ e^{i\\pi} + 1 = 0 \\]
+
+\\[\\boxed{boxed包裹}\\]
 
 ### 块级公式
 1. 傅里叶变换：

--- a/packages/core/src/components/XMarkdownCore/hooks/index.ts
+++ b/packages/core/src/components/XMarkdownCore/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useComponents';
+export * from './useMarkdown';
 export * from './useMermaid';
 export * from './useMermaidZoom';
 export * from './usePlugins';

--- a/packages/core/src/components/XMarkdownCore/hooks/useMarkdown.ts
+++ b/packages/core/src/components/XMarkdownCore/hooks/useMarkdown.ts
@@ -1,0 +1,42 @@
+import { flow } from 'lodash-es';
+
+export function useProcessMarkdown(markdown: string) {
+  return preprocessLaTeX(markdown);
+}
+
+export function preprocessLaTeX(markdown: string) {
+  if (typeof markdown !== 'string') return markdown;
+
+  const codeBlockRegex = /```[\s\S]*?```/g;
+  const codeBlocks = markdown.match(codeBlockRegex) || [];
+  const escapeReplacement = (str: string) => str.replace(/\$/g, '_ELX_DOLLAR_');
+  let processedMarkdown = markdown.replace(
+    codeBlockRegex,
+    'ELX_CODE_BLOCK_PLACEHOLDER'
+  );
+
+  processedMarkdown = flow([
+    (str: string) =>
+      str.replace(/\\\[(.*?)\\\]/g, (_, equation) => `$$${equation}$$`),
+    (str: string) =>
+      str.replace(/\\\[([\s\S]*?)\\\]/g, (_, equation) => `$$${equation}$$`),
+    (str: string) =>
+      str.replace(/\\\((.*?)\\\)/g, (_, equation) => `$$${equation}$$`),
+    (str: string) =>
+      str.replace(
+        /(^|[^\\])\$(.+?)\$/g,
+        (_, prefix, equation) => `${prefix}$${equation}$`
+      )
+  ])(processedMarkdown);
+
+  codeBlocks.forEach(block => {
+    processedMarkdown = processedMarkdown.replace(
+      'ELX_CODE_BLOCK_PLACEHOLDER',
+      escapeReplacement(block)
+    );
+  });
+
+  processedMarkdown = processedMarkdown.replace(/_ELX_DOLLAR_/g, '$');
+
+  return processedMarkdown;
+}


### PR DESCRIPTION
Now, you can use [] to render mathematical formulas

```markdown
\\[ e^{i\\pi} + 1 = 0 \\]

\\[\\boxed{boxed包裹}\\]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LaTeX/Math rendering in Markdown when enabled, automatically converting common LaTeX delimiters (\[...\], \(...\), $...$) to a MathJax-friendly format.
  * Ensures code blocks are preserved and not parsed as math, improving readability and reliability.
  * Updated sample content with display-math examples (e.g., Euler’s identity and boxed expressions) to showcase capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->