### PR TITLE
feat: 给xMarkdown增加enableCodePreview、enableThemeToggle、enableCodeCopy

### DIFF
--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/index.vue
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/index.vue
@@ -37,12 +37,7 @@ const props = withDefaults(
 );
 
 const context = useMarkdownContext();
-const {
-  codeXSlot,
-  customAttrs,
-  enableCodeLineNumber = false,
-  globalShiki
-} = toValue(context) || {};
+const { codeXSlot, customAttrs, globalShiki } = toValue(context) || {};
 const renderLines = ref<string[]>([]);
 const preStyle = ref<any | null>(null);
 const preClass = ref<string | null>(null);
@@ -203,6 +198,11 @@ watch(
     }
   }
 );
+
+// 获取是否显示行号
+const enableCodeLineNumber = computed(() => {
+  return context?.value?.codeXProps?.enableCodeLineNumber ?? false;
+});
 </script>
 
 <template>

--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/shiki-header.ts
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/shiki-header.ts
@@ -6,7 +6,7 @@ import type {
   ElxRunCodeExposeProps
 } from '../RunCode/type';
 import type { RawProps } from './types';
-import { MARKDOWN_PROVIDER_KEY } from '@components/XMarkdownCore/shared';
+import { useMarkdownContext } from '@components/XMarkdownCore/components/MarkdownProvider';
 import { ArrowDownBold, Moon, Sunny } from '@element-plus/icons-vue';
 import { ElButton, ElMessage, ElSpace } from 'element-plus';
 import { h, ref } from 'vue';
@@ -243,7 +243,8 @@ export function controlEle(copy: () => void) {
  * @param view
  */
 export function controlHasRunCodeEle(copy: () => void, view: () => void) {
-  const contextProps = inject(MARKDOWN_PROVIDER_KEY) as ComputedRef;
+  const context = useMarkdownContext();
+  const { codeXProps } = toValue(context) || {};
   return h(
     ElSpace,
     {
@@ -252,13 +253,11 @@ export function controlHasRunCodeEle(copy: () => void, view: () => void) {
     },
     {
       default: () => [
-        contextProps?.value?.enableCodePreview
+        codeXProps?.enableCodePreview
           ? h(RunCodeButton, { onView: view })
           : null,
-        contextProps?.value?.enableThemeToggle ? toggleThemeEle() : null,
-        contextProps?.value?.enableCodeCopy
-          ? h(CopyCodeButton, { onCopy: copy })
-          : null // ✅ 改为组件形式
+        codeXProps?.enableThemeToggle ? toggleThemeEle() : null,
+        codeXProps?.enableCodeCopy ? h(CopyCodeButton, { onCopy: copy }) : null // ✅ 改为组件形式
       ]
     }
   );

--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/shiki-header.ts
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/shiki-header.ts
@@ -6,6 +6,7 @@ import type {
   ElxRunCodeExposeProps
 } from '../RunCode/type';
 import type { RawProps } from './types';
+import { MARKDOWN_PROVIDER_KEY } from '@components/XMarkdownCore/shared';
 import { ArrowDownBold, Moon, Sunny } from '@element-plus/icons-vue';
 import { ElButton, ElMessage, ElSpace } from 'element-plus';
 import { h, ref } from 'vue';
@@ -238,11 +239,11 @@ export function controlEle(copy: () => void) {
  * @description 描述 语言头部操作按钮(带预览代码按钮)
  * @date 2025-07-09 11:15:27
  * @author tingfeng
- *
- * @export
  * @param copy
+ * @param view
  */
 export function controlHasRunCodeEle(copy: () => void, view: () => void) {
+  const contextProps = inject(MARKDOWN_PROVIDER_KEY) as ComputedRef;
   return h(
     ElSpace,
     {
@@ -251,9 +252,13 @@ export function controlHasRunCodeEle(copy: () => void, view: () => void) {
     },
     {
       default: () => [
-        h(RunCodeButton, { onView: view }),
-        toggleThemeEle(),
-        h(CopyCodeButton, { onCopy: copy }) // ✅ 改为组件形式
+        contextProps?.value?.enableCodePreview
+          ? h(RunCodeButton, { onView: view })
+          : null,
+        contextProps?.value?.enableThemeToggle ? toggleThemeEle() : null,
+        contextProps?.value?.enableCodeCopy
+          ? h(CopyCodeButton, { onCopy: copy })
+          : null // ✅ 改为组件形式
       ]
     }
   );

--- a/packages/core/src/components/XMarkdownCore/components/MarkdownProvider/index.ts
+++ b/packages/core/src/components/XMarkdownCore/components/MarkdownProvider/index.ts
@@ -32,6 +32,11 @@ const MarkdownProvider = defineComponent({
     const processProps = computed(() => {
       return {
         ...props,
+        codeXProps: Object.assign(
+          {},
+          MARKDOWN_CORE_PROPS.codeXProps.default(),
+          props.codeXProps
+        ),
         markdown: markdown.value
       };
     });

--- a/packages/core/src/components/XMarkdownCore/shared/constants.ts
+++ b/packages/core/src/components/XMarkdownCore/shared/constants.ts
@@ -1,4 +1,5 @@
 import type { GlobalShiki } from '@components/XMarkdownCore/hooks/useShiki';
+import type { CodeXProps } from '@components/XMarkdownCore/shared/types';
 import type { BuiltinTheme } from 'shiki';
 import type { PluggableList } from 'unified';
 import type { MermaidToolbarConfig } from '../components/Mermaid/types';
@@ -17,10 +18,7 @@ export const DEFAULT_PROPS = {
   enableLatex: true,
   enableAnimate: false,
   enableBreaks: true,
-  enableCodePreview: false, // 启动代码预览功能
-  enableCodeCopy: true, // 启动代码复制功能
-  enableThemeToggle: false, // 启动主题切换
-  enableCodeLineNumber: false,
+  codeXProps: () => ({}),
   codeXRender: () => ({}),
   codeXSlot: () => ({}),
   codeHighlightTheme: null,
@@ -51,22 +49,6 @@ export const MARKDOWN_CORE_PROPS = {
     type: Boolean,
     default: false
   },
-  enableCodePreview: {
-    type: Boolean,
-    default: true
-  },
-  enableCodeCopy: {
-    type: Boolean,
-    default: true
-  },
-  enableThemeToggle: {
-    type: Boolean,
-    default: true
-  },
-  enableCodeLineNumber: {
-    type: Boolean,
-    default: false
-  },
   enableLatex: {
     type: Boolean,
     default: true
@@ -78,6 +60,15 @@ export const MARKDOWN_CORE_PROPS = {
   enableBreaks: {
     type: Boolean,
     default: true
+  },
+  codeXProps: {
+    type: Object as PropType<CodeXProps>,
+    default: () => ({
+      enableCodePreview: false, // 启动代码预览功能
+      enableCodeCopy: true, // 启动代码复制功能
+      enableThemeToggle: false, // 启动主题切换
+      enableCodeLineNumber: false
+    })
   },
   codeXRender: {
     type: Object,

--- a/packages/core/src/components/XMarkdownCore/shared/constants.ts
+++ b/packages/core/src/components/XMarkdownCore/shared/constants.ts
@@ -17,6 +17,9 @@ export const DEFAULT_PROPS = {
   enableLatex: true,
   enableAnimate: false,
   enableBreaks: true,
+  enableCodePreview: false, // 启动代码预览功能
+  enableCodeCopy: true, // 启动代码复制功能
+  enableThemeToggle: false, // 启动主题切换
   enableCodeLineNumber: false,
   codeXRender: () => ({}),
   codeXSlot: () => ({}),
@@ -47,6 +50,18 @@ export const MARKDOWN_CORE_PROPS = {
   allowHtml: {
     type: Boolean,
     default: false
+  },
+  enableCodePreview: {
+    type: Boolean,
+    default: true
+  },
+  enableCodeCopy: {
+    type: Boolean,
+    default: true
+  },
+  enableThemeToggle: {
+    type: Boolean,
+    default: true
   },
   enableCodeLineNumber: {
     type: Boolean,

--- a/packages/core/src/components/XMarkdownCore/shared/types.d.ts
+++ b/packages/core/src/components/XMarkdownCore/shared/types.d.ts
@@ -9,6 +9,9 @@ export type MarkdownProps = {
   enableLatex?: boolean;
   enableAnimate?: boolean;
   enableBreaks?: boolean;
+  enableCodePreview?: boolean; // 启动代码预览功能
+  enableCodeCopy?: boolean; // 启动代码复制功能
+  enableThemeToggle?: boolean; // 启动主题切换
   codeXRender?: Record<string, any>;
   codeXSlot?: CodeBlockHeaderExpose & Record<string, any>;
   codeHighlightTheme?: BuiltinTheme | null;

--- a/packages/core/src/components/XMarkdownCore/shared/types.d.ts
+++ b/packages/core/src/components/XMarkdownCore/shared/types.d.ts
@@ -5,13 +5,10 @@ import type { InitShikiOptions } from './shikiHighlighter';
 
 export type MarkdownProps = {
   allowHtml?: boolean;
-  enableCodeLineNumber?: boolean;
   enableLatex?: boolean;
   enableAnimate?: boolean;
   enableBreaks?: boolean;
-  enableCodePreview?: boolean; // 启动代码预览功能
-  enableCodeCopy?: boolean; // 启动代码复制功能
-  enableThemeToggle?: boolean; // 启动主题切换
+  codeXProps?: CodeXProps;
   codeXRender?: Record<string, any>;
   codeXSlot?: CodeBlockHeaderExpose & Record<string, any>;
   codeHighlightTheme?: BuiltinTheme | null;
@@ -36,3 +33,10 @@ export type MarkdownProps = {
 
 export type MarkdownProviderProps = Omit<MarkdownProps, 'markdown'> &
   Partial<Pick<MarkdownProps, 'markdown'>>;
+
+export interface CodeXProps {
+  enableCodePreview?: boolean; // 启动代码预览功能
+  enableCodeCopy?: boolean; // 启动代码复制功能
+  enableThemeToggle?: boolean; // 启动主题切换
+  enableCodeLineNumber?: boolean; // 开启行号
+}

--- a/packages/core/src/stories/XMarkdown/Markdown.stories.ts
+++ b/packages/core/src/stories/XMarkdown/Markdown.stories.ts
@@ -93,12 +93,9 @@ export const highlightMdContentDemo: Story = {
   args: {
     markdown: highlightMdContent,
     codeXProps: {
-      enableCodePreview: false,
-      enableThemeToggle: false,
-      enableCodeCopy: true,
       enableCodeLineNumber: true
     }
-  },
+  } as any,
   render: args => ({
     components: { HighlightCodeDemo },
     setup() {

--- a/packages/core/src/stories/XMarkdown/Markdown.stories.ts
+++ b/packages/core/src/stories/XMarkdown/Markdown.stories.ts
@@ -85,12 +85,19 @@ export const MarkdownDemo: Story = {
 
 export const highlightMdContentDemo: Story = {
   argTypes: {
-    enableCodePreview: { control: 'boolean' },
-    enableThemeToggle: { control: 'boolean' },
-    enableCodeCopy: { control: 'boolean' }
+    codeXProps: {
+      control: 'object',
+      defaultValue: {}
+    }
   } as any,
   args: {
-    markdown: highlightMdContent
+    markdown: highlightMdContent,
+    codeXProps: {
+      enableCodePreview: false,
+      enableThemeToggle: false,
+      enableCodeCopy: true,
+      enableCodeLineNumber: true
+    }
   },
   render: args => ({
     components: { HighlightCodeDemo },

--- a/packages/core/src/stories/XMarkdown/Markdown.stories.ts
+++ b/packages/core/src/stories/XMarkdown/Markdown.stories.ts
@@ -84,13 +84,16 @@ export const MarkdownDemo: Story = {
 };
 
 export const highlightMdContentDemo: Story = {
+  argTypes: {
+    enableCodePreview: { control: 'boolean' },
+    enableThemeToggle: { control: 'boolean' },
+    enableCodeCopy: { control: 'boolean' }
+  } as any,
   args: {
     markdown: highlightMdContent
   },
   render: args => ({
-    components: {
-      HighlightCodeDemo
-    },
+    components: { HighlightCodeDemo },
     setup() {
       return { attrs: args };
     },


### PR DESCRIPTION
给xMarkdown增加enableCodePreview、enableThemeToggle、enableCodeCopy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Code block controls (Run/Preview, Copy, Theme Toggle, Line Numbers) are now grouped under a single configurable prop and can be toggled at runtime.
  - Header controls are rendered conditionally based on those runtime flags, producing a cleaner, context-aware UI.

- Documentation
  - Storybook updated with interactive controls and example defaults for code-related features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->