### PR TITLE
feat(conversations): add manually control the drop-down menu

### DIFF
--- a/apps/docs/en/components/conversations/index.md
+++ b/apps/docs/en/components/conversations/index.md
@@ -65,7 +65,7 @@ title: Conversations
 | `#groupTitle`  | `{ group: GroupItem }`                                    | Custom group title, supports adding icons or special styles                                                |
 | `#label`       | `{ item: ConversationItem<T> }`                           | Custom session item label content, supports text overflow handling or rich text                            |
 | `#more-filled` | `{ item, isHovered, isActive, isMenuOpened, isDisabled }` | Session item right side additional content, displays status indicators (e.g.: disabled mark, action icons) |
-| `#menu`        | `{ item: ConversationItem<T> }`                           | Custom menu content, supports buttons, icons or complex interactive components                             |
+| `#menu`        | `{ item: ConversationItem<T>, handleOpen, handleClose }`                           | Custom menu content, supports buttons, icons or complex interactive components,`handleOpen`used to control the opening of the drop-down menu, `handleClose`used to control the closing of drop-down menus.                             |
 | `#header`      | -                                                         | Container header slot, for adding search bars, filter buttons and other custom content                     |
 | `#footer`      | -                                                         | Container footer slot, for adding pagination, statistics and other custom content                          |
 

--- a/apps/docs/zh/components/conversations/index.md
+++ b/apps/docs/zh/components/conversations/index.md
@@ -64,7 +64,7 @@ title: 'Conversations'
 | `#groupTitle`  | `{ group: GroupItem }`                                    | 自定义分组标题，支持添加图标或特殊样式                     |
 | `#label`       | `{ item: ConversationItem<T> }`                           | 自定义会话项标签内容，支持文本溢出处理或富文本             |
 | `#more-filled` | `{ item, isHovered, isActive, isMenuOpened, isDisabled }` | 会话项右侧附加内容，显示状态标识（如：禁用标记、操作图标） |
-| `#menu`        | `{ item: ConversationItem<T> }`                           | 自定义菜单内容，支持按钮、图标或复杂交互组件               |
+| `#menu`        | `{ item: ConversationItem<T>, handleOpen, handleClose }`                           | 自定义菜单内容，支持按钮、图标或复杂交互组件,`handleOpen`用来手动控制下拉菜单的开启,`handleClose`用来手动控制下拉菜单的关闭.               |
 | `#header`      | -                                                         | 容器头部插槽，用于添加搜索栏、筛选按钮等自定义内容         |
 | `#footer`      | -                                                         | 容器底部插槽，用于添加分页、统计信息等自定义内容           |
 

--- a/packages/core/src/components/Conversations/components/item.vue
+++ b/packages/core/src/components/Conversations/components/item.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ElDropdown } from 'element-plus';
 import type { Component, CSSProperties } from 'vue';
 import type {
   ConversationItem,
@@ -87,7 +88,8 @@ const {
 } = toRefs(props);
 
 function renderIcon(icon: Component | null | undefined) {
-  if (!icon) return null;
+  if (!icon)
+    return null;
   return h(icon);
 }
 
@@ -101,6 +103,8 @@ const suffixIconRender = computed(() => {
 
 // 添加hover状态跟踪
 const isHovered = ref(false);
+
+const elDropdownRef = ref<InstanceType<typeof ElDropdown> | null>(null);
 
 function handleMouseEnter() {
   isHovered.value = true;
@@ -117,7 +121,8 @@ function handleClick(key: string) {
 const isTextOverflow = computed(() => {
   return (label: string = '') => {
     // 如果没有设置labelMaxWidth，直接返回false
-    if (!labelMaxWidth.value) return false;
+    if (!labelMaxWidth.value)
+      return false;
 
     // 创建一个临时的span元素来测量文本宽度
     const span = document.createElement('span');
@@ -252,6 +257,10 @@ function menuCommand(
   }
   emit('menuCommand', command, item);
 }
+
+onMounted(() => {
+  console.log(elDropdownRef.value, '------');
+});
 /* 内置菜单 结束 */
 </script>
 
@@ -279,14 +288,14 @@ function menuCommand(
     <div class="conversation-content">
       <!-- 标签区域 - 通过插槽自定义 -->
       <div class="conversation-content-main">
-        <slot name="label">
-          <!-- 前缀图标 -->
-          <span v-if="prefixIconRender" class="conversation-prefix-icon">
-            <el-icon>
-              <component :is="prefixIconRender" />
-            </el-icon>
-          </span>
+        <!-- 前缀图标 -->
+        <span v-if="prefixIconRender" class="conversation-prefix-icon">
+          <el-icon>
+            <component :is="prefixIconRender" />
+          </el-icon>
+        </span>
 
+        <slot name="label">
           <!-- 标签和时间戳 -->
           <div class="conversation-label-container">
             <ElTooltip
@@ -300,16 +309,14 @@ function menuCommand(
                 class="conversation-label"
                 :class="{ 'text-gradient': isTextOverflow(item.label) }"
                 :style="labelStyle"
-                >{{ item.label }}</span
-              >
+              >{{ item.label }}</span>
             </ElTooltip>
             <span
               v-else
               class="conversation-label"
               :class="{ 'text-gradient': isTextOverflow(item.label) }"
               :style="labelStyle"
-              >{{ item.label }}</span
-            >
+            >{{ item.label }}</span>
           </div>
         </slot>
       </div>
@@ -323,16 +330,17 @@ function menuCommand(
 
       <!-- 菜单区域 - 只在hover或active状态下显示 -->
       <div
-        v-if="(shouldShowMenu && showBuiltInMenu) || alwaysShowBuiltInMenu"
+        v-show="(shouldShowMenu && showBuiltInMenu) || alwaysShowBuiltInMenu"
         class="conversation-dropdown-menu-container"
       >
         <div
-          v-if="menu && menu.length"
+          v-show="menu && menu.length"
           ref="menuButtonRef"
           class="conversation-dropdown-more"
           @click="e => e.stopPropagation()"
         >
           <el-dropdown
+            ref="elDropdownRef"
             trigger="click"
             :placement="menuPlacement"
             :offset="menuOffset"
@@ -351,6 +359,7 @@ function menuCommand(
           >
             <template #default>
               <slot
+
                 name="more-filled"
                 v-bind="{
                   item,
@@ -366,7 +375,7 @@ function menuCommand(
               </slot>
             </template>
             <template #dropdown>
-              <slot name="menu">
+              <slot name="menu" v-bind="{ handleOpen: elDropdownRef?.handleOpen, handleClose: elDropdownRef?.handleClose }">
                 <el-dropdown-menu :style="mergedMenuStyle">
                   <el-dropdown-item
                     v-for="menuItem in menu"

--- a/packages/core/src/components/Conversations/index.vue
+++ b/packages/core/src/components/Conversations/index.vue
@@ -139,7 +139,8 @@ const mergedStyle = computed(() => {
 
 function handleClick(item: ConversationItemUseOptions<T>) {
   // 如果是disabled状态，则不允许选中
-  if (item.disabled) return;
+  if (item.disabled)
+    return;
   emits('change', item);
   activeKey.value = item.uniqueKey as string | number;
 }
@@ -158,7 +159,8 @@ const filteredItems = computed(() => {
 // 根据分组方式进行分组
 const groups = computed(() => {
   // 如果不需要分组，则返回空数组
-  if (!shouldUseGrouping.value) return [];
+  if (!shouldUseGrouping.value)
+    return [];
 
   // 检查filteredItems是否有值
   if (!filteredItems.value || filteredItems.value.length === 0) {
@@ -200,8 +202,10 @@ const groups = computed(() => {
   if (typeof props.groupable === 'object' && props.groupable.sort) {
     return groupArray.sort((a, b) => {
       // 确保未分组总是在最后
-      if (a.isUngrouped) return 1;
-      if (b.isUngrouped) return -1;
+      if (a.isUngrouped)
+        return 1;
+      if (b.isUngrouped)
+        return -1;
 
       const sortFn = (props.groupable as GroupableOptions).sort;
       return sortFn ? sortFn(a.key, b.key) : 0;
@@ -211,8 +215,10 @@ const groups = computed(() => {
   // 否则只确保未分组在最后，不做其他排序
   return groupArray.sort((a, b) => {
     // 确保未分组总是在最后
-    if (a.isUngrouped) return 1;
-    if (b.isUngrouped) return -1;
+    if (a.isUngrouped)
+      return 1;
+    if (b.isUngrouped)
+      return -1;
 
     // 不做其他排序
     return 0;
@@ -235,11 +241,13 @@ function handleScroll(e: any) {
 
   // 获取当前滚动容器
   const scrollbar = scrollbarRef.value;
-  if (!scrollbar) return;
+  if (!scrollbar)
+    return;
 
   // 使用scrollbar的wrapRef获取真实DOM以获取正确的尺寸
   const wrap = scrollbar.wrapRef;
-  if (!wrap) return;
+  if (!wrap)
+    return;
 
   // 检查是否需要加载更多
   // 当滚动到距离底部20px时触发加载
@@ -260,14 +268,16 @@ function handleScroll(e: any) {
 
 // 更新标题吸顶状态
 function updateStickyStatus(_e: any) {
-  if (!shouldUseGrouping.value || groups.value.length === 0) return;
+  if (!shouldUseGrouping.value || groups.value.length === 0)
+    return;
 
   // 先清空当前的吸顶组
   stickyGroupKeys.value.clear();
 
   // 获取滚动容器
   const scrollContainer = scrollbarRef.value?.wrapRef;
-  if (!scrollContainer) return;
+  if (!scrollContainer)
+    return;
 
   // 如果只有一个分组，直接设置为吸顶状态
   if (groups.value.length === 1) {
@@ -333,7 +343,8 @@ function updateStickyStatus(_e: any) {
 
 // 加载更多数据
 function loadMoreData() {
-  if (!props.loadMore) return;
+  if (!props.loadMore)
+    return;
   props.loadMore();
 }
 
@@ -447,8 +458,8 @@ onMounted(() => {
                       <slot name="more-filled" v-bind="moreFilledSoltProps" />
                     </template>
 
-                    <template v-if="$slots.menu" #menu>
-                      <slot name="menu" v-bind="{ item }" />
+                    <template v-if="$slots.menu" #menu="{ handleOpen, handleClose }">
+                      <slot name="menu" v-bind="{ item, handleOpen, handleClose }" />
                     </template>
                   </Item>
                 </div>
@@ -497,8 +508,8 @@ onMounted(() => {
                   <slot name="more-filled" v-bind="moreFilledSoltProps" />
                 </template>
 
-                <template v-if="$slots.menu" #menu>
-                  <slot name="menu" v-bind="{ item }" />
+                <template v-if="$slots.menu" #menu="{ handleOpen, handleClose }">
+                  <slot name="menu" v-bind="{ item, handleOpen, handleClose }" />
                 </template>
               </Item>
             </template>


### PR DESCRIPTION
fix: #347 

menu插槽提供el-dropdown实例暴漏的手动关闭和打开下拉菜单的方法，可以让用户手动控制下拉菜单

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Conversations: The menu slot now provides handleOpen and handleClose alongside item, enabling programmatic open/close control of each item's dropdown menu from your slot content. Backward compatible with existing usage.

- Documentation
  - Updated English and Chinese docs to reflect the new menu slot signature and clarify how to manually control the dropdown menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->