### PR TITLE
fix(bubble):修复无内容时气泡高度问题

### DIFF
--- a/packages/core/src/components/Bubble/index.vue
+++ b/packages/core/src/components/Bubble/index.vue
@@ -67,11 +67,9 @@ const DEFAULT_TYPING: TypingConfig = {
 const _typing = computed(() => {
   if (typeof props.typing === 'undefined') {
     return false;
-  }
-  else if (typeof props.typing === 'boolean') {
+  } else if (typeof props.typing === 'boolean') {
     return props.typing;
-  }
-  else {
+  } else {
     return Object.assign({}, DEFAULT_TYPING, props.typing);
   }
 }) as boolean | TypingConfig;
@@ -178,7 +176,8 @@ defineExpose(instance);
           'el-bubble-content-filled': variant === 'filled' && !noStyle,
           'el-bubble-content-borderless': variant === 'borderless' && !noStyle,
           'el-bubble-content-outlined': variant === 'outlined' && !noStyle,
-          'el-bubble-content-shadow': variant === 'shadow' && !noStyle
+          'el-bubble-content-shadow': variant === 'shadow' && !noStyle,
+          'no-content': !content
         }"
       >
         <div

--- a/packages/core/src/components/Bubble/style.scss
+++ b/packages/core/src/components/Bubble/style.scss
@@ -72,13 +72,18 @@
     color: var(--el-text-color-primary);
     font-size: var(--el-font-size-base);
     line-height: var(--el-font-line-height-primary);
-    min-height: calc(var(--el-padding-sm, 12px) * 2 + var(--el-font-line-height-primary) * var(--el-font-size-base));
+    min-height: calc(
+      var(--el-padding-sm, 12px) * 2 + var(--el-font-line-height-primary) *
+        var(--el-font-size-base)
+    );
     word-break: break-word;
 
     // 打字器没有内容时候展示高度
+    &.no-content,
     .no-content {
       // height: 16px;
       height: 0;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
- 在 Bubble 组件中添加 'no-content' 类名判断
- 当应用 content 为空时 'no-content' 样式
- 修改样式文件使无内容气泡高度为0
- 移除无内容气泡的内边距

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a no-content state for bubbles to better handle empty messages.
- Style
  - Refined bubble layout when no content is present by removing extra spacing, resulting in tighter, cleaner rendering.
- Bug Fixes
  - Eliminated unintended padding/height in empty bubbles to prevent visual gaps.
- Documentation
  - Clarified empty-state behavior in bubble rendering (no functional changes to typing or content flow).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->