### PR TITLE
fix(XMarkdown): 修复代码块控制按钮显示逻辑

### DIFF
--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/index.vue
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/index.vue
@@ -18,7 +18,6 @@ import { useMarkdownContext } from '../MarkdownProvider';
 import RunCode from '../RunCode/index.vue';
 import {
   controlEle,
-  controlHasRunCodeEle,
   copyCode,
   isDark,
   languageEle,
@@ -43,7 +42,13 @@ const preStyle = ref<any | null>(null);
 const preClass = ref<string | null>(null);
 const themes = computed(() => context?.value?.themes ?? shikiThemeDefault);
 const colorReplacements = computed(() => context?.value?.colorReplacements);
-const nowViewBtnShow = computed(() => context?.value?.needViewCodeBtn ?? false);
+// 当 needViewCodeBtn 为 true 或 enableCodePreview 为 true 时，启用 HTML 代码块的特殊处理
+const nowViewBtnShow = computed(() => {
+  const needViewCodeBtn = context?.value?.needViewCodeBtn ?? false;
+  const enableCodePreview =
+    context?.value?.codeXProps?.enableCodePreview ?? false;
+  return needViewCodeBtn || enableCodePreview;
+});
 const viewCodeModalOptions = computed(
   () => context?.value?.viewCodeModalOptions
 );
@@ -175,19 +180,12 @@ const RunCodeComputed = computed(() => {
     : undefined;
 });
 const codeControllerEleComputed = computed(() => {
-  if (nowCodeLanguage.value === 'html' && nowViewBtnShow.value) {
-    return controlHasRunCodeEle(
-      () => {
-        copyCode(renderLines.value);
-      },
-      () => {
-        viewCode(renderLines.value);
-      }
-    );
-  }
-  return controlEle(() => {
-    copyCode(renderLines.value);
-  });
+  const viewCallback =
+    nowCodeLanguage.value === 'html' && nowViewBtnShow.value
+      ? () => viewCode(renderLines.value)
+      : undefined;
+
+  return controlEle(() => copyCode(renderLines.value), viewCallback);
 });
 
 watch(

--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/shiki-header.ts
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/shiki-header.ts
@@ -219,7 +219,12 @@ export function languageEle(language: string) {
  * @export
  * @param {() => void} copy
  */
-export function controlEle(copy: () => void) {
+export function controlEle(copy: () => void, view?: () => void) {
+  const context = useMarkdownContext();
+  const { codeXProps, needViewCodeBtn } = toValue(context) || {};
+  const shouldShowPreview =
+    view && (needViewCodeBtn || codeXProps?.enableCodePreview);
+
   return h(
     ElSpace,
     {
@@ -228,8 +233,9 @@ export function controlEle(copy: () => void) {
     },
     {
       default: () => [
+        shouldShowPreview ? h(RunCodeButton, { onView: view }) : null,
         toggleThemeEle(),
-        h(CopyCodeButton, { onCopy: copy }) // ✅ 改为组件形式
+        h(CopyCodeButton, { onCopy: copy })
       ]
     }
   );
@@ -239,28 +245,12 @@ export function controlEle(copy: () => void) {
  * @description 描述 语言头部操作按钮(带预览代码按钮)
  * @date 2025-07-09 11:15:27
  * @author tingfeng
+ * @deprecated 已废弃，请使用 controlEle 代替
  * @param copy
  * @param view
  */
 export function controlHasRunCodeEle(copy: () => void, view: () => void) {
-  const context = useMarkdownContext();
-  const { codeXProps } = toValue(context) || {};
-  return h(
-    ElSpace,
-    {
-      class: `markdown-elxLanguage-header-space`,
-      direction: 'horizontal'
-    },
-    {
-      default: () => [
-        codeXProps?.enableCodePreview
-          ? h(RunCodeButton, { onView: view })
-          : null,
-        codeXProps?.enableThemeToggle ? toggleThemeEle() : null,
-        codeXProps?.enableCodeCopy ? h(CopyCodeButton, { onCopy: copy }) : null // ✅ 改为组件形式
-      ]
-    }
-  );
+  return controlEle(copy, view);
 }
 
 /**


### PR DESCRIPTION
重构控制按钮渲染函数，统一 controlEle 和 controlHasRunCodeEle 的逻辑， 修复 needViewCodeBtn 导致主题切换按钮异常隐藏的问题。

Closes #418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code blocks now feature improved preview button visibility and behavior with enhanced controls for HTML code examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->