### PR TITLE
fix(XSender): 用 @layer 隔离 x-sender CSS，修复污染 ant-design-vue 样式问题 (#458)

### DIFF
--- a/packages/core/.build/plugins/index.ts
+++ b/packages/core/.build/plugins/index.ts
@@ -3,18 +3,20 @@ import vue from '@vitejs/plugin-vue';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 import autoImportPlugin from './autoImport';
 import dtsPlugin from './dts';
+import xSenderCssLayerPlugin from './xSenderCssLayer';
 // import prismjsPlugin from './prismjs'
 
 const plugins: PluginOption[] = [
   vue({
     script: {
-      propsDestructure: true,
-    },
+      propsDestructure: true
+    }
   }) as PluginOption,
   // prismjsPlugin,
   ...autoImportPlugin,
   dtsPlugin as PluginOption,
   libInjectCss() as PluginOption,
+  xSenderCssLayerPlugin() as PluginOption
 ];
 
 export default plugins;

--- a/packages/core/.build/plugins/xSenderCssLayer.ts
+++ b/packages/core/.build/plugins/xSenderCssLayer.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'vite';
+
+/**
+ * 将 x-sender 的 CSS 包裹进 @layer，避免其内部的 .ant 等样式污染用户项目中 ant-design-vue 的全局样式。
+ *
+ * @layer 内的样式优先级低于任何非 @layer 的普通样式，因此 ant-design-vue 的样式天然优先，互不干扰。
+ */
+export default function xSenderCssLayerPlugin(): Plugin {
+  return {
+    name: 'vite-plugin-x-sender-css-layer',
+    transform(code, id) {
+      if (id.includes('x-sender') && id.endsWith('.css')) {
+        return {
+          code: `@layer element-plus-x-third-party {
+${code}
+}`,
+          map: null
+        };
+      }
+    }
+  };
+}


### PR DESCRIPTION
XSender组件引入的第三方库x-sender样式文件内部包含ant-spin等css样式，会污染ant-design-vue的原生样式
使用[@layer](https://www.w3school.com.cn/cssref/atrule_layer.asp)隔离样式，后续想修改XSender组件的ant等样式可使用样式穿透
```
 :deep(.el-editor-sender-wrap .ant-spin .ant-spin-dot-item) {
    background-color: red;
  }
```
效果如下
<img width="351" height="240" alt="image" src="https://github.com/user-attachments/assets/d5383bf3-e387-4f37-86df-3c8b8276e93a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CSS layer scoping for third-party stylesheets to improve cascade control and specificity management during the build process. This enhancement better organizes styles and helps reduce potential styling conflicts within the stylesheet hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->