### PR TITLE
fix(Attachments): 修复拖拽上传遮罩显示问题 & fix(FilesCard): 修复预览图片原图、缩略图逻辑问题

### DIFF
--- a/packages/core/src/components/Attachments/index.vue
+++ b/packages/core/src/components/Attachments/index.vue
@@ -143,11 +143,13 @@ function getTargetElement() {
 }
 
 function targetDragEnter(event: DragEvent) {
+  if (props.hideUpload) return;
   event.preventDefault();
   debouncedStyle(true);
 }
 
 function targetDropLeave(event: DragEvent) {
+  if (props.hideUpload) return;
   event.preventDefault();
   // 新增逻辑：若离开后进入的元素仍在目标元素内部，不执行样式移除
   const relatedTarget = event.relatedTarget as Node;
@@ -158,6 +160,7 @@ function targetDropLeave(event: DragEvent) {
 }
 
 function targetDrop(event: DragEvent) {
+  if (props.hideUpload) return;
   event.preventDefault();
   debouncedStyle(false);
   if (event.dataTransfer) {
@@ -169,7 +172,39 @@ function targetDrop(event: DragEvent) {
 }
 
 function targetDragOver(event: DragEvent) {
+  if (props.hideUpload) return;
   event.preventDefault();
+}
+
+function removeDragListenersFrom(element: HTMLElement) {
+  element.removeEventListener('dragenter', targetDragEnter, false);
+  element.removeEventListener('dragleave', targetDropLeave, false);
+  element.removeEventListener('drop', targetDrop, false);
+  element.removeEventListener('dragover', targetDragOver, false);
+}
+
+function removeDragListeners() {
+  if (targetElement.value) {
+    removeDragListenersFrom(targetElement.value);
+  }
+  debouncedStyle(false);
+}
+
+function addDragListeners() {
+  if (!wrapperRef.value || props.hideUpload) return;
+
+  const element = getTargetElement() || wrapperRef.value;
+  if (!element) return;
+
+  if (targetElement.value && targetElement.value !== element) {
+    removeDragListenersFrom(targetElement.value);
+  }
+
+  targetElement.value = element;
+  element.addEventListener('dragenter', targetDragEnter, false);
+  element.addEventListener('dragleave', targetDropLeave, false);
+  element.addEventListener('drop', targetDrop, false);
+  element.addEventListener('dragover', targetDragOver, false);
 }
 
 /* 上传相关 结束 */
@@ -187,33 +222,12 @@ onMounted(() => {
   nextTick(() => debouncedCheckPing());
   window.addEventListener('resize', debouncedCheckPing);
 
-  // 如果有拖拽目标元素，则监听拖拽事件
-  if (wrapperRef.value) {
-    targetElement.value = getTargetElement() || wrapperRef.value;
-    // 监听拖拽事件
-    targetElement.value.addEventListener('dragenter', targetDragEnter, false);
-    targetElement.value.addEventListener('dragleave', targetDropLeave, false);
-    targetElement.value.addEventListener('drop', targetDrop, false);
-    targetElement.value.addEventListener('dragover', targetDragOver, false);
-  }
+  addDragListeners();
 });
 
 onUnmounted(() => {
   window.removeEventListener('resize', debouncedCheckPing);
-  if (targetElement.value) {
-    targetElement.value.removeEventListener(
-      'dragenter',
-      targetDragEnter,
-      false
-    );
-    targetElement.value.removeEventListener(
-      'dragleave',
-      targetDropLeave,
-      false
-    );
-    targetElement.value.removeEventListener('drop', targetDrop, false);
-    targetElement.value.removeEventListener('dragover', targetDragOver, false);
-  }
+  removeDragListeners();
 });
 
 watch(
@@ -228,33 +242,16 @@ watch(
   }
 );
 
-// 监听 props.dragTarget
+// 监听 dragTarget / hideUpload，动态绑定或解绑拖拽上传
 watch(
-  () => props.dragTarget,
+  () => [props.dragTarget, props.hideUpload],
   () => {
-    // 确保 DOM 更新后再调用 checkPing
     nextTick(() => {
-      // 如果有拖拽目标元素，则监听拖拽事件
-      if (wrapperRef.value) {
-        targetElement.value = getTargetElement() || wrapperRef.value;
-        // 监听拖拽事件
-        targetElement.value.addEventListener(
-          'dragenter',
-          targetDragEnter,
-          false
-        );
-        targetElement.value.addEventListener(
-          'dragleave',
-          targetDropLeave,
-          false
-        );
-        targetElement.value.addEventListener('drop', targetDrop, false);
-        targetElement.value.addEventListener('dragover', targetDragOver, false);
-      }
+      removeDragListeners();
+      addDragListeners();
     });
   },
   {
-    immediate: true, // 组件初始化时立即调用一次
     deep: true
   }
 );
@@ -410,7 +407,10 @@ defineExpose({
     </slot>
 
     <!-- 使用 DropArea 组件 -->
-    <teleport v-if="targetElement && isTargetDrag" :to="targetElement">
+    <teleport
+      v-if="targetElement && isTargetDrag && !props.hideUpload"
+      :to="targetElement"
+    >
       <slot name="drop-area">
         <div ref="dropAreaRef" class="elx-attachments-drop-area">
           <el-icon class="elx-attachments-drop-area-icon">

--- a/packages/core/src/components/FilesCard/index.vue
+++ b/packages/core/src/components/FilesCard/index.vue
@@ -77,11 +77,18 @@ const _description = computed(() => {
 
 const isImageFile = computed(() => _fileType.value === 'image');
 const isSquareVariant = computed(() => imgVariant.value === 'square');
-const _previewImgUrl = computed(() => {
+// 缩略图展示：优先 thumbUrl，其次 url / 本地预览
+const _displayImgUrl = computed(() => {
   if (!isImageFile.value) return undefined;
   if (thumbUrl.value) return thumbUrl.value;
   if (url.value) return url.value;
   return _previewImg.value;
+});
+// 大图预览：优先原图 url，无原图时回退到缩略图
+const _previewSrcList = computed(() => {
+  if (!isImageFile.value || !props.imgPreview) return [];
+  const previewUrl = url.value || thumbUrl.value || _previewImg.value;
+  return previewUrl ? [previewUrl] : [];
 });
 
 const _iconSize = computed(() => {
@@ -118,7 +125,12 @@ function handleDelete() {
 // 遮罩展开时触发预览
 const imgRef = ref();
 function handlePreviewAction(type: 'self' | 'mask') {
-  if (props.imgPreview && imgRef.value && _previewImgUrl && type === 'mask') {
+  if (
+    props.imgPreview &&
+    imgRef.value &&
+    _displayImgUrl.value &&
+    type === 'mask'
+  ) {
     imgRef.value!.showPreview();
   }
   if (type === 'self') {
@@ -178,11 +190,11 @@ defineExpose({
           @mouseleave="imageHovered = false"
         >
           <el-image
-            v-if="_previewImgUrl"
+            v-if="_displayImgUrl"
             ref="imgRef"
             class="elx-files-card-img"
-            :src="_previewImgUrl"
-            :preview-src-list="props.imgPreview ? [_previewImgUrl] : []"
+            :src="_displayImgUrl"
+            :preview-src-list="_previewSrcList"
             fit="cover"
             :show-progress="false"
             hide-on-click-modal
@@ -203,7 +215,7 @@ defineExpose({
             <slot
               v-if="
                 imageHovered &&
-                _previewImgUrl &&
+                _displayImgUrl &&
                 props.imgPreviewMask &&
                 props.imgPreview
               "


### PR DESCRIPTION
fix(Attachments): 修复拖拽上传遮罩显示问题 & fix(FilesCard): 修复预览图片原图、缩略图逻辑问题

## 🔗 相关 Issue

无

## 📝 变更类型

- [ ] 🚀 feat: 新增功能
- [✅] 🐛 fix: 修复缺陷
- [ ] 📚 docs: 文档更新
- [ ] 💄 style: 代码格式（不影响逻辑）
- [ ] ♻️ refactor: 代码重构
- [ ] ⚡ perf: 性能优化
- [ ] ✅ test: 测试相关
- [ ] 📦 build: 构建相关
- [ ] 👷 ci: CI 配置
- [ ] 🔧 chore: 其他修改
- [ ] ⏪ revert: 回退代码
- [ ] 💥 breaking: 破坏性变更

## 📋 变更说明

设置 `hideUpload` 后，默认上传按钮会隐藏，但拖拽文件到组件区域（或 `dragTarget` 指定区域）时，仍会出现「在此处拖放文件上传」遮罩，并可能触发 `uploadDrop` 事件。

在 `FilesCard` 组件中，当同时传入 `thumbUrl`（缩略图）和 `url`（原图）时，点击预览查看大图仍显示缩略图，无法看到原图。

## 🧪 测试计划

- [ ] 已添加单元测试
- [ ] 已添加集成测试
- [✅] 已手动测试


## ✅ Checklist

- [ ] 遵循项目的代码规范（commitlint）
- [ ] 已进行自我代码审查
- [ ] 代码已通过 lint 检查
- [ ] 已更新相关文档
- [ ] 变更不会产生新的警告
- [ ] 已添加必要的测试
- [ ] 所有测试通过

## 📦 Changeset

无

### Changeset 类型

无

## 修改文档
[hideUpload-drag-fix.md](https://github.com/user-attachments/files/29531390/hideUpload-drag-fix.md)
[thumbUrl-preview-fix.md](https://github.com/user-attachments/files/29531396/thumbUrl-preview-fix.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drag-and-drop upload behavior now correctly respects hidden upload settings, preventing unintended drop areas and upload actions from appearing.
  * Image previews now use the best available image source more reliably, improving preview consistency for uploaded files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->