### PR TITLE
fix(XSender): upgrade x-sender to fix IME input bugs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,7 +87,7 @@
     "ts-md5": "^2.0.1",
     "typescript-api-pro": "^0.0.6",
     "virtua": "^0.49.1",
-    "x-sender": "^1.3.3"
+    "x-sender": "^1.4.3"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
         specifier: ^3.5.17
         version: 3.5.18(typescript@5.8.3)
       x-sender:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.4.3
+        version: 1.4.6
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^4.16.1
@@ -6198,9 +6198,8 @@ packages:
       shiki-stream:
         optional: true
 
-  x-sender@1.3.3:
-    resolution: {integrity: sha512-ts9zRKhMFSXIa4mhEGM3q+HQzFwSH/1Iq0vnD0qdVyFSuO5deZSGeXyFPWj8ClMF0EM5f/Irph2GtgxAKRqVEA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+  x-sender@1.4.6:
+    resolution: {integrity: sha512-B2aKDunizbkaBHan0MX3cu0Kv6kT7eSRqVQzc2r+7ZqwuiMjOfhz3hyvM+jEvpuQWu5fhTZORWHqtzt368mctw==}
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -13400,7 +13399,7 @@ snapshots:
       - '@vue/composition-api'
       - supports-color
 
-  x-sender@1.3.3: {}
+  x-sender@1.4.6: {}
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
## 这次改了什么

#496 的升级方向是对的，但它基于旧 `main`，直接改 base 会带出一大堆和修复无关的 diff。所以我保留了原提交的作者信息，把它移到了现在的 `updata-2602`。

- `x-sender` 从 `^1.3.3` 升到 `^1.4.3`
- lockfile 现在解析到 `1.4.6`
- 等这条合并后，旧的 #496 就可以按 superseded 关掉

## 我跑过的检查

- `pnpm install --frozen-lockfile`
- `pnpm build:core`
- 实际安装版本确认是 `x-sender@1.4.6`

Closes #495
关联 #488