### PR TITLE
docs(useSend): fix broken hook-fetch link

### DIFF
--- a/apps/docs/en/components/useSend/index.md
+++ b/apps/docs/en/components/useSend/index.md
@@ -2,8 +2,7 @@
 title: UseSend
 ---
 
-
-## XRequest is deprecated, recommend using hook-fetch (https://jsonlee12138.github.io/hook-fetch/)
+## XRequest is deprecated; use [hook-fetch](https://jsonlee12138.github.io/hook-fetch/) instead
 
 ## Background Introduction
 

--- a/apps/docs/zh/components/useSend/index.md
+++ b/apps/docs/zh/components/useSend/index.md
@@ -2,7 +2,7 @@
 title: 'useSend'
 ---
 
-## XRequest已废弃，推荐使用 hook-fetch（https://jsonlee12138.github.io/hook-fetch/）
+## XRequest 已废弃，推荐使用 [hook-fetch](https://jsonlee12138.github.io/hook-fetch/)
 
 ## 背景介绍
 


### PR DESCRIPTION
我看了下 #431，hook-fetch 站点本身没问题，404 是因为文档把 URL 直接写在全角括号里，渲染后右括号也被算进链接了。

这次把中英文 useSend 页都改成了标准 Markdown 链接。

我跑过：
- `pnpm --dir apps/docs build`

完整 `pnpm build:docs` 会先刷新 GitHub 贡献者数据，当时撞到 API 限流；我用临时空的贡献者 JSON 跑了实际 VitePress 构建，构建通过，临时文件没有进提交。

Closes #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `useSend` deprecation notices in English and Chinese documentation.
  * Added a clearly formatted link directing users to `hook-fetch`.
  * Improved spacing and readability of the Chinese notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->