### PR TITLE
perf(Thinking): 修正展开收起箭头方向

### DIFF
--- a/packages/core/src/components/Thinking/index.vue
+++ b/packages/core/src/components/Thinking/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ThinkingEmits, ThinkingProps, ThinkingStatus } from './types';
 import {
-  ArrowUpBold,
+  ArrowDownBold,
   CircleCloseFilled,
   Loading,
   Opportunity,
@@ -149,7 +149,7 @@ watch(
         >
           <slot name="arrow">
             <el-icon :class="ns.e('icon-center')">
-              <ArrowUpBold />
+              <ArrowDownBold />
             </el-icon>
           </slot>
         </span>


### PR DESCRIPTION
我把 #216 移到了现在的 `updata-2602`，原作者和提交信息都保留了。

v2 里这个问题还在：收起时应该显示向下箭头，展开后再由现有的 180° 旋转变成向上箭头。移植时只保留了 `ArrowUpBold` 到 `ArrowDownBold` 这一个行为改动，没有带旧 main 的代码。

我跑过：
- `pnpm build:core`

等这条合并后，#216 可以按已移植关闭。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Thinking component’s expand/collapse arrow icon to display the appropriate direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->