### PR TITLE
feat(FilesCard): 支持 previewTeleported

### DIFF
--- a/apps/docs/en/components/filesCard/index.md
+++ b/apps/docs/en/components/filesCard/index.md
@@ -43,28 +43,29 @@ Override `FilesCard` theme tokens via `ConfigProvider.themeOverrides`. See the f
 
 ## Properties
 
-| Property Name    | Type                               | Required | Default           | Description                                                                                       |
-| ---------------- | ---------------------------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------------- |
-| `uid`            | `string \| number`                 | Yes      |                   | File unique identifier                                                                            |
-| `name`           | `string`                           | No       | `undefined`       | File name (supports automatic suffix parsing to match icons)                                      |
-| `fileSize`       | `number`                           | No       | `undefined`       | File size (unit: bytes, automatically converted to readable format)                               |
-| `fileType`       | `string`                           | No       | `undefined`       | File type (priority higher than `name` suffix parsing, e.g. `'image'`, `'document'`)              |
-| `description`    | `string`                           | No       | `undefined`       | Description text (supports dynamic generation of file type and size info)                         |
-| `url`            | `string`                           | No       | `undefined`       | File access URL (image files can be used for preview)                                             |
-| `thumbUrl`       | `string`                           | No       | `undefined`       | Image thumbnail URL                                                                               |
-| `imgFile`        | `File \| Blob`                     | No       | `undefined`       | Image file stream (automatically parsed as preview URL, only for temporary display before upload) |
-| `iconSize`       | `string`                           | No       | `'42px'`          | Icon/image size                                                                                   |
-| `iconColor`      | `string`                           | No       | `undefined`       | Icon color for non-image files (supports custom color values)                                     |
-| `showDelIcon`    | `boolean`                          | No       | `false`           | Whether to show hover delete icon                                                                 |
-| `maxWidth`       | `string`                           | No       | `'236px'`         | Card maximum width                                                                                |
-| `style`          | `CSSProperties`                    | No       | `undefined`       | Card custom styles                                                                                |
-| `hoverStyle`     | `CSSProperties`                    | No       | `undefined`       | Card custom styles when hovering                                                                  |
-| `imgVariant`     | `'rectangle' \| 'square'`          | No       | `'rectangle'`     | Image card form (rectangle/square)                                                                |
-| `imgPreview`     | `boolean`                          | No       | `true`            | Whether to enable image preview functionality                                                     |
-| `imgPreviewMask` | `boolean`                          | No       | `true`            | Whether to show image preview mask overlay                                                        |
-| `status`         | `'uploading' \| 'done' \| 'error'` | No       | `undefined`       | File status (controls progress bar, error prompts and other visual feedback)                      |
-| `percent`        | `number`                           | No       | `0`               | Upload progress percentage (used with `status="uploading"`)                                       |
-| `errorTip`       | `string`                           | No       | `'Upload failed'` | Custom error status prompt text                                                                   |
+| Property Name       | Type                               | Required | Default           | Description                                                                                                          |
+| ------------------- | ---------------------------------- | -------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `uid`               | `string \| number`                 | Yes      |                   | File unique identifier                                                                                               |
+| `name`              | `string`                           | No       | `undefined`       | File name (supports automatic suffix parsing to match icons)                                                         |
+| `fileSize`          | `number`                           | No       | `undefined`       | File size (unit: bytes, automatically converted to readable format)                                                  |
+| `fileType`          | `string`                           | No       | `undefined`       | File type (priority higher than `name` suffix parsing, e.g. `'image'`, `'document'`)                                 |
+| `description`       | `string`                           | No       | `undefined`       | Description text (supports dynamic generation of file type and size info)                                            |
+| `url`               | `string`                           | No       | `undefined`       | File access URL (image files can be used for preview)                                                                |
+| `thumbUrl`          | `string`                           | No       | `undefined`       | Image thumbnail URL                                                                                                  |
+| `imgFile`           | `File \| Blob`                     | No       | `undefined`       | Image file stream (automatically parsed as preview URL, only for temporary display before upload)                    |
+| `iconSize`          | `string`                           | No       | `'42px'`          | Icon/image size                                                                                                      |
+| `iconColor`         | `string`                           | No       | `undefined`       | Icon color for non-image files (supports custom color values)                                                        |
+| `showDelIcon`       | `boolean`                          | No       | `false`           | Whether to show hover delete icon                                                                                    |
+| `maxWidth`          | `string`                           | No       | `'236px'`         | Card maximum width                                                                                                   |
+| `style`             | `CSSProperties`                    | No       | `undefined`       | Card custom styles                                                                                                   |
+| `hoverStyle`        | `CSSProperties`                    | No       | `undefined`       | Card custom styles when hovering                                                                                     |
+| `imgVariant`        | `'rectangle' \| 'square'`          | No       | `'rectangle'`     | Image card form (rectangle/square)                                                                                   |
+| `imgPreview`        | `boolean`                          | No       | `true`            | Whether to enable image preview functionality                                                                        |
+| `imgPreviewMask`    | `boolean`                          | No       | `true`            | Whether to show image preview mask overlay                                                                           |
+| `previewTeleported` | `boolean`                          | No       | `false`           | Whether to teleport the image viewer to `body`; enable it when an ancestor creates a transformed or stacking context |
+| `status`            | `'uploading' \| 'done' \| 'error'` | No       | `undefined`       | File status (controls progress bar, error prompts and other visual feedback)                                         |
+| `percent`           | `number`                           | No       | `0`               | Upload progress percentage (used with `status="uploading"`)                                                          |
+| `errorTip`          | `string`                           | No       | `'Upload failed'` | Custom error status prompt text                                                                                      |
 
 ## Slots
 

--- a/apps/docs/zh/components/filesCard/index.md
+++ b/apps/docs/zh/components/filesCard/index.md
@@ -43,28 +43,29 @@ title: 'FilesCard'
 
 ## 属性
 
-| 属性名           | 类型                               | 是否必填 | 默认值        | 描述                                                               |
-| ---------------- | ---------------------------------- | -------- | ------------- | ------------------------------------------------------------------ |
-| `uid`            | `string \| number`                 | 是       |               | 文件唯一标识符                                                     |
-| `name`           | `string`                           | 否       | `undefined`   | 文件名（支持自动解析后缀匹配图标）                                 |
-| `fileSize`       | `number`                           | 否       | `undefined`   | 文件大小（单位：字节，自动转换为易读格式）                         |
-| `fileType`       | `string`                           | 否       | `undefined`   | 文件类型（优先级高于 `name` 后缀解析，如 `'image'`、`'document'`） |
-| `description`    | `string`                           | 否       | `undefined`   | 描述文本（支持动态生成文件类型和大小信息）                         |
-| `url`            | `string`                           | 否       | `undefined`   | 文件访问地址（图片文件可用于预览）                                 |
-| `thumbUrl`       | `string`                           | 否       | `undefined`   | 图片缩略图地址                                                     |
-| `imgFile`        | `File \| Blob`                     | 否       | `undefined`   | 图片文件流（自动解析为预览地址，仅用于上传前临时展示）             |
-| `iconSize`       | `string`                           | 否       | `'42px'`      | 图标/图片尺寸                                                      |
-| `iconColor`      | `string`                           | 否       | `undefined`   | 非图片文件的图标颜色（支持自定义色值）                             |
-| `showDelIcon`    | `boolean`                          | 否       | `false`       | 是否显示悬停删除图标                                               |
-| `maxWidth`       | `string`                           | 否       | `'236px'`     | 卡片最大宽度                                                       |
-| `style`          | `CSSProperties`                    | 否       | `undefined`   | 卡片自定义样式                                                     |
-| `hoverStyle`     | `CSSProperties`                    | 否       | `undefined`   | 卡片悬停时的自定义样式                                             |
-| `imgVariant`     | `'rectangle' \| 'square'`          | 否       | `'rectangle'` | 图片卡片形态（长方形/正方形）                                      |
-| `imgPreview`     | `boolean`                          | 否       | `true`        | 是否开启图片预览功能                                               |
-| `imgPreviewMask` | `boolean`                          | 否       | `true`        | 是否显示图片预览遮罩蒙层                                           |
-| `status`         | `'uploading' \| 'done' \| 'error'` | 否       | `undefined`   | 文件状态（控制进度条、错误提示等视觉反馈）                         |
-| `percent`        | `number`                           | 否       | `0`           | 上传进度百分比（配合 `status="uploading"` 使用）                   |
-| `errorTip`       | `string`                           | 否       | `'上传失败'`  | 错误状态自定义提示文本                                             |
+| 属性名              | 类型                               | 是否必填 | 默认值        | 描述                                                                         |
+| ------------------- | ---------------------------------- | -------- | ------------- | ---------------------------------------------------------------------------- |
+| `uid`               | `string \| number`                 | 是       |               | 文件唯一标识符                                                               |
+| `name`              | `string`                           | 否       | `undefined`   | 文件名（支持自动解析后缀匹配图标）                                           |
+| `fileSize`          | `number`                           | 否       | `undefined`   | 文件大小（单位：字节，自动转换为易读格式）                                   |
+| `fileType`          | `string`                           | 否       | `undefined`   | 文件类型（优先级高于 `name` 后缀解析，如 `'image'`、`'document'`）           |
+| `description`       | `string`                           | 否       | `undefined`   | 描述文本（支持动态生成文件类型和大小信息）                                   |
+| `url`               | `string`                           | 否       | `undefined`   | 文件访问地址（图片文件可用于预览）                                           |
+| `thumbUrl`          | `string`                           | 否       | `undefined`   | 图片缩略图地址                                                               |
+| `imgFile`           | `File \| Blob`                     | 否       | `undefined`   | 图片文件流（自动解析为预览地址，仅用于上传前临时展示）                       |
+| `iconSize`          | `string`                           | 否       | `'42px'`      | 图标/图片尺寸                                                                |
+| `iconColor`         | `string`                           | 否       | `undefined`   | 非图片文件的图标颜色（支持自定义色值）                                       |
+| `showDelIcon`       | `boolean`                          | 否       | `false`       | 是否显示悬停删除图标                                                         |
+| `maxWidth`          | `string`                           | 否       | `'236px'`     | 卡片最大宽度                                                                 |
+| `style`             | `CSSProperties`                    | 否       | `undefined`   | 卡片自定义样式                                                               |
+| `hoverStyle`        | `CSSProperties`                    | 否       | `undefined`   | 卡片悬停时的自定义样式                                                       |
+| `imgVariant`        | `'rectangle' \| 'square'`          | 否       | `'rectangle'` | 图片卡片形态（长方形/正方形）                                                |
+| `imgPreview`        | `boolean`                          | 否       | `true`        | 是否开启图片预览功能                                                         |
+| `imgPreviewMask`    | `boolean`                          | 否       | `true`        | 是否显示图片预览遮罩蒙层                                                     |
+| `previewTeleported` | `boolean`                          | 否       | `false`       | 是否将图片预览层挂载到 `body`，父元素存在 `transform` 或层叠上下文时建议开启 |
+| `status`            | `'uploading' \| 'done' \| 'error'` | 否       | `undefined`   | 文件状态（控制进度条、错误提示等视觉反馈）                                   |
+| `percent`           | `number`                           | 否       | `0`           | 上传进度百分比（配合 `status="uploading"` 使用）                             |
+| `errorTip`          | `string`                           | 否       | `'上传失败'`  | 错误状态自定义提示文本                                                       |
 
 ## 插槽
 

--- a/packages/core/src/components/FilesCard/index.vue
+++ b/packages/core/src/components/FilesCard/index.vue
@@ -24,6 +24,7 @@ const props = withDefaults(defineProps<FilesCardProps>(), {
   imgVariant: 'rectangle',
   imgPreview: true,
   imgPreviewMask: true,
+  previewTeleported: false,
   status: undefined,
   percent: undefined,
   errorTip: undefined
@@ -195,6 +196,7 @@ defineExpose({
             class="elx-files-card-img"
             :src="_displayImgUrl"
             :preview-src-list="_previewSrcList"
+            :preview-teleported="props.previewTeleported"
             fit="cover"
             :show-progress="false"
             hide-on-click-modal

--- a/packages/core/src/components/FilesCard/types.d.ts
+++ b/packages/core/src/components/FilesCard/types.d.ts
@@ -38,6 +38,8 @@ export interface FilesCardProps {
   imgVariant?: 'rectangle' | 'square';
   // 图片是否开启预览
   imgPreview?: boolean;
+  // image-viewer 是否插入至 body 元素上。 嵌套的父元素属性会发生修改时应该将此属性设置为 true
+  previewTeleported?: boolean;
   // 是否显示预览遮罩
   imgPreviewMask?: boolean;
 

--- a/packages/core/src/stories/FilesCard/FilesCard.stories.ts
+++ b/packages/core/src/stories/FilesCard/FilesCard.stories.ts
@@ -102,6 +102,11 @@ const meta: Meta<typeof FilesCardSource> = {
       description: '是否显示图片预览遮罩蒙层',
       defaultValue: true
     },
+    previewTeleported: {
+      control: 'boolean',
+      description: '预览是否使用 teleport 插入至 body 元素上',
+      defaultValue: false
+    },
     status: {
       control: { type: 'radio' },
       options: ['uploading', 'done', 'error'],


### PR DESCRIPTION
我把 #311 移到了现在的 `updata-2602`，原作者和提交信息都保留了。

#299 在 v2.0.3 里还会复现，因为 FilesCard 没有把 Element Plus 的 `preview-teleported` 传给 `el-image`。这次补了：
- `previewTeleported` prop，默认 false，不改原来的行为
- `el-image` 参数透传
- 中英文文档
- Storybook 控件

冲突处理时保留了 v2 新增的主题文档，也顺手把旧 PR 里这条 prop 的中英文说明写清楚了。

我跑过：
- `pnpm build:core`
- `pnpm --dir packages/core build:storybook`

Storybook 构建成功；过程中有项目原有的全局设置目录权限和类型路径告警，不是这次改动带来的。

Closes #299

等这条合并后，#311 可以按已移植关闭。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `previewTeleported` option to control whether image previews are rendered under the document body.
  - The option is disabled by default.
  - Added interactive configuration support for this behavior in the component examples.

- **Documentation**
  - Documented the new option and updated the properties tables in English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->