### PR TITLE
feat(BubbleList): 给内置插槽补充 index

### DIFF
--- a/packages/core/src/components/BubbleList/index.vue
+++ b/packages/core/src/components/BubbleList/index.vue
@@ -9,7 +9,8 @@ import type {
   BubbleListItemContext,
   BubbleListItemProps,
   BubbleListProps,
-  BubbleListScrollState
+  BubbleListScrollState,
+  BubbleListSlots
 } from './types';
 import { ArrowDownBold } from '@element-plus/icons-vue';
 import { Virtualizer } from 'virtua/vue';
@@ -50,6 +51,9 @@ const props = withDefaults(defineProps<BubbleListProps<T>>(), {
 });
 
 const emit = defineEmits<BubbleListEmits>();
+
+defineSlots<BubbleListSlots<T>>();
+
 const instance = getCurrentInstance();
 const ns = useNamespace('bubble-list');
 const MESSAGE_ITEM_TYPES = new Set(['bubble', 'message']);
@@ -1209,19 +1213,19 @@ defineExpose({
               :no-style="item.noStyle"
             >
               <template v-if="$slots.avatar" #avatar>
-                <slot name="avatar" :item="item" />
+                <slot name="avatar" :item="item" :index="index" />
               </template>
               <template v-if="$slots.header" #header>
-                <slot name="header" :item="item" />
+                <slot name="header" :item="item" :index="index" />
               </template>
               <template v-if="$slots.content" #content>
-                <slot name="content" :item="item" />
+                <slot name="content" :item="item" :index="index" />
               </template>
               <template v-if="$slots.footer" #footer>
-                <slot name="footer" :item="item" />
+                <slot name="footer" :item="item" :index="index" />
               </template>
               <template v-if="$slots.loading" #loading>
-                <slot name="loading" :item="item" />
+                <slot name="loading" :item="item" :index="index" />
               </template>
             </Bubble>
           </template>
@@ -1276,19 +1280,19 @@ defineExpose({
                   :no-style="item.noStyle"
                 >
                   <template v-if="$slots.avatar" #avatar>
-                    <slot name="avatar" :item="item" />
+                    <slot name="avatar" :item="item" :index="index" />
                   </template>
                   <template v-if="$slots.header" #header>
-                    <slot name="header" :item="item" />
+                    <slot name="header" :item="item" :index="index" />
                   </template>
                   <template v-if="$slots.content" #content>
-                    <slot name="content" :item="item" />
+                    <slot name="content" :item="item" :index="index" />
                   </template>
                   <template v-if="$slots.footer" #footer>
-                    <slot name="footer" :item="item" />
+                    <slot name="footer" :item="item" :index="index" />
                   </template>
                   <template v-if="$slots.loading" #loading>
-                    <slot name="loading" :item="item" />
+                    <slot name="loading" :item="item" :index="index" />
                   </template>
                 </Bubble>
               </template>

--- a/packages/core/src/components/BubbleList/types.d.ts
+++ b/packages/core/src/components/BubbleList/types.d.ts
@@ -55,6 +55,27 @@ export interface BubbleListItemContext<
   autoScroll: boolean;
 }
 
+export interface BubbleListBubbleSlotContext<
+  T extends BubbleListItemProps = BubbleListItemProps
+> {
+  item: T;
+  index: number;
+}
+
+export interface BubbleListSlots<
+  T extends BubbleListItemProps = BubbleListItemProps
+> {
+  avatar?: (context: BubbleListBubbleSlotContext<T>) => unknown;
+  header?: (context: BubbleListBubbleSlotContext<T>) => unknown;
+  content?: (context: BubbleListBubbleSlotContext<T>) => unknown;
+  footer?: (context: BubbleListBubbleSlotContext<T>) => unknown;
+  loading?: (context: BubbleListBubbleSlotContext<T>) => unknown;
+  item?: (context: BubbleListItemContext<T>) => unknown;
+  topStatus?: (context: BubbleListBoundaryContext) => unknown;
+  bottomStatus?: (context: BubbleListBoundaryContext) => unknown;
+  backToBottom?: (context: BubbleListBackButtonContext) => unknown;
+}
+
 export interface BubbleListBoundaryState {
   type: BubbleListBoundaryStateType;
   text?: string;


### PR DESCRIPTION
我把 #345 的需求按现在的 v2 BubbleList 重新做了一版，原作者已经放进 co-author。

旧 PR 不能直接搬，因为 v2 现在有普通列表和虚拟列表两条渲染路径。这次两边都补了：
- `#avatar`
- `#header`
- `#content`
- `#footer`
- `#loading`

这些插槽现在都能拿到 `{ item, index }`。另外补了 `defineSlots` 类型，item、topStatus、bottomStatus、backToBottom 这些现有插槽也会有正确的上下文提示。

我跑过：
- `pnpm build:core`

Closes #272

等这条合并后，#345 可以按已重做关闭。