### PR TITLE
fix(Bubble): 修复空内容气泡占位

### DIFF
--- a/packages/core/src/components/Bubble/index.vue
+++ b/packages/core/src/components/Bubble/index.vue
@@ -106,6 +106,9 @@ defineExpose({
         :class="[
           ns.e('content'),
           loading ? ns.em('content', 'loading') : '',
+          !loading && !content && !$slots.content
+            ? ns.em('content', 'empty')
+            : '',
           shape === 'round' && !noStyle ? ns.em('content', 'round') : '',
           shape === 'corner' && !noStyle ? ns.em('content', 'corner') : '',
           variant === 'filled' && !noStyle ? ns.em('content', 'filled') : '',

--- a/packages/core/src/components/Bubble/style.scss
+++ b/packages/core/src/components/Bubble/style.scss
@@ -81,12 +81,13 @@
         var(--el-font-size-base)
     );
     word-break: break-word;
+  }
 
-    // 打字器没有内容时候展示高度
-    .no-content {
-      // height: 16px;
-      height: 0;
-    }
+  .elx-bubble__content--empty {
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    box-shadow: none;
   }
 
   // 气泡圆角

--- a/packages/core/src/components/Bubble/style.scss
+++ b/packages/core/src/components/Bubble/style.scss
@@ -83,13 +83,6 @@
     word-break: break-word;
   }
 
-  .elx-bubble__content--empty {
-    min-height: 0;
-    padding: 0;
-    border: 0;
-    box-shadow: none;
-  }
-
   // 气泡圆角
   .elx-bubble__content--round {
     border-radius: var(--el-border-radius-round);
@@ -116,6 +109,13 @@
     background: none;
     // box-shadow: var(--el-box-shadow-tertiary);
     box-shadow: var(--elx-bubble-shadow, var(--el-box-shadow));
+  }
+
+  .elx-bubble__content--empty {
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    box-shadow: none;
   }
 
   .elx-bubble__content--loading {


### PR DESCRIPTION
我把 #373 的问题按现在的 v2 Bubble 重做了，原作者已经放进 co-author。

原 PR 直接按 `!content` 压缩气泡，这样 `loading=true` 但 content 为空时也会被压成 0，自定义 content 插槽也可能受影响。这次只在下面三个条件同时成立时进入空态：
- 没有 content
- 不是 loading
- 没有自定义 content 插槽

空态会去掉最小高度、padding、border 和 shadow；加载动画、自定义内容、header/footer 都保留原来的行为。

我跑过：
- `pnpm build:core`

Closes #372

等这条合并后，#373 可以按已重做关闭。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the appearance of empty, non-loading chat bubbles by removing unnecessary spacing, borders, and shadows.
  * Corrected empty bubble styling for a cleaner, more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->