### PR TITLE
fix(XSender): 隔离 x-sender 的全局 ant 样式

### DIFF
--- a/packages/core/.build/plugins/index.ts
+++ b/packages/core/.build/plugins/index.ts
@@ -3,18 +3,20 @@ import vue from '@vitejs/plugin-vue';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 import autoImportPlugin from './autoImport';
 import dtsPlugin from './dts';
+import xSenderCssLayerPlugin from './xSenderCssLayer';
 // import prismjsPlugin from './prismjs'
 
 const plugins: PluginOption[] = [
   vue({
     script: {
-      propsDestructure: true,
-    },
+      propsDestructure: true
+    }
   }) as PluginOption,
   // prismjsPlugin,
   ...autoImportPlugin,
   dtsPlugin as PluginOption,
   libInjectCss() as PluginOption,
+  xSenderCssLayerPlugin() as PluginOption
 ];
 
 export default plugins;

--- a/packages/core/.build/plugins/index.ts
+++ b/packages/core/.build/plugins/index.ts
@@ -9,14 +9,14 @@ import xSenderCssLayerPlugin from './xSenderCssLayer';
 const plugins: PluginOption[] = [
   vue({
     script: {
-      propsDestructure: true
-    }
+      propsDestructure: true,
+    },
   }) as PluginOption,
   // prismjsPlugin,
   ...autoImportPlugin,
   dtsPlugin as PluginOption,
   libInjectCss() as PluginOption,
-  xSenderCssLayerPlugin() as PluginOption
+  xSenderCssLayerPlugin() as PluginOption,
 ];
 
 export default plugins;

--- a/packages/core/.build/plugins/xSenderCssLayer.ts
+++ b/packages/core/.build/plugins/xSenderCssLayer.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'vite';
+
+/**
+ * 将 x-sender 的 CSS 包裹进 @layer，避免其内部的 .ant 等样式污染用户项目中 ant-design-vue 的全局样式。
+ *
+ * @layer 内的样式优先级低于任何非 @layer 的普通样式，因此 ant-design-vue 的样式天然优先，互不干扰。
+ */
+export default function xSenderCssLayerPlugin(): Plugin {
+  return {
+    name: 'vite-plugin-x-sender-css-layer',
+    transform(code, id) {
+      if (id.includes('x-sender') && id.endsWith('.css')) {
+        return {
+          code: `@layer element-plus-x-third-party {
+${code}
+}`,
+          map: null
+        };
+      }
+    }
+  };
+}

--- a/packages/core/.build/plugins/xSenderCssLayer.ts
+++ b/packages/core/.build/plugins/xSenderCssLayer.ts
@@ -9,14 +9,21 @@ export default function xSenderCssLayerPlugin(): Plugin {
   return {
     name: 'vite-plugin-x-sender-css-layer',
     transform(code, id) {
-      if (id.includes('x-sender') && id.endsWith('.css')) {
-        return {
-          code: `@layer element-plus-x-third-party {
+      const cleanId = id.split('?')[0].replaceAll('\\', '/');
+      const isXSenderStyle =
+        cleanId.includes('/node_modules/x-sender/') &&
+        cleanId.endsWith('/lib/XSender.css');
+
+      if (!isXSenderStyle) {
+        return;
+      }
+
+      return {
+        code: `@layer element-plus-x-third-party {
 ${code}
 }`,
-          map: null
-        };
-      }
+        map: null
+      };
     }
   };
 }


### PR DESCRIPTION
我把 #463 移到了最新的 `updata-2602`，原作者提交完整保留。

`x-sender` 自带的 CSS 里有 `.ant-spin` 等全局选择器，会影响同一个项目里的 ant-design-vue。原 PR 用 `@layer` 隔离的方向是对的，我另外处理了 review 里提到的匹配问题：
- 先去掉 Vite 的 `?used` / `?inline` 查询参数
- 只匹配 `node_modules/x-sender/lib/XSender.css`
- 不再用宽泛的 `includes("x-sender") && endsWith(".css")`

我跑过：
- `pnpm build:core`
- 检查 `dist/es/XSender/index.css`，x-sender 的 `:root`、`.ant-spin` 和 keyframes 都在 `@layer element-plus-x-third-party` 里面

Closes #458

等这条合并后，#463 可以按已移植关闭。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved style compatibility when using XSender alongside Ant Design Vue.
  * Prevented XSender styles from unintentionally overriding global application styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->