### PR TITLE
fix(Conversations): 修复容器宽度不生效

### DIFF
--- a/apps/docs/en/components/conversations/index.md
+++ b/apps/docs/en/components/conversations/index.md
@@ -61,6 +61,7 @@ Override `Conversations` theme tokens via `ConfigProvider.themeOverrides`. See t
 | `showToTopBtn`         | `boolean`                     | No       | `false`   | Whether to show back to top button                                                       |
 | `labelKey`             | `string`                      | No       | `'label'` | Session item label field name                                                            |
 | `rowKey`               | `string`                      | No       | `'id'`    | Session item unique identifier field name                                                |
+| `style`                | `CSSProperties`               | No       | `{}`      | Container styles; use `width` to set the conversation list width                         |
 | `itemsStyle`           | `CSSProperties`               | No       | `{}`      | Session item default style                                                               |
 | `itemsHoverStyle`      | `CSSProperties`               | No       | `{}`      | Session item hover style                                                                 |
 | `itemsActiveStyle`     | `CSSProperties`               | No       | `{}`      | Session item active style                                                                |

--- a/apps/docs/zh/components/conversations/index.md
+++ b/apps/docs/zh/components/conversations/index.md
@@ -61,6 +61,7 @@ title: 'Conversations'
 | `showToTopBtn`         | `boolean`                     | 否       | `false`   | 是否显示返回顶部按钮                                      |
 | `labelKey`             | `string`                      | 否       | `'label'` | 会话项标签字段名                                          |
 | `rowKey`               | `string`                      | 否       | `'id'`    | 会话项唯一标识字段名                                      |
+| `style`                | `CSSProperties`               | 否       | `{}`      | 容器样式，可通过 `width` 设置会话列表宽度                 |
 | `itemsStyle`           | `CSSProperties`               | 否       | `{}`      | 会话项默认样式                                            |
 | `itemsHoverStyle`      | `CSSProperties`               | 否       | `{}`      | 会话项悬停样式                                            |
 | `itemsActiveStyle`     | `CSSProperties`               | 否       | `{}`      | 会话项激活样式                                            |

--- a/packages/core/src/components/Conversations/index.vue
+++ b/packages/core/src/components/Conversations/index.vue
@@ -117,7 +117,9 @@ const mergedStyle = computed(() => {
 });
 
 const containerStyle = computed(() => {
+  const width = mergedStyle.value.width;
   return ns.cssVarBlock({
+    'container-width': typeof width === 'number' ? `${width}px` : width,
     'label-height': `${props.labelHeight}px`,
     'list-auto-bg-color': mergedStyle.value.backgroundColor as string
   });

--- a/packages/core/src/components/Conversations/index.vue
+++ b/packages/core/src/components/Conversations/index.vue
@@ -113,7 +113,11 @@ const mergedStyle = computed(() => {
     width: '280px',
     height: '0'
   };
-  return { ...defaultStyle, ...props.style };
+  return {
+    ...defaultStyle,
+    ...props.style,
+    width: props.style?.width ?? defaultStyle.width
+  };
 });
 
 const containerStyle = computed(() => {

--- a/packages/core/src/components/Conversations/style.scss
+++ b/packages/core/src/components/Conversations/style.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   height: 100%;
   position: relative;
-  width: fit-content;
+  width: var(--elx-conversations-container-width, fit-content);
   box-sizing: border-box;
   overflow: hidden;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);

--- a/packages/core/src/stories/Conversations/Conversations.stories.ts
+++ b/packages/core/src/stories/Conversations/Conversations.stories.ts
@@ -65,7 +65,15 @@ const meta: Meta<typeof ConversationsSource> = {
       description: '会话项菜单打开时样式',
       control: 'object',
       defaultValue: {}
+    },
+    style: {
+      description: '会话列表容器样式',
+      control: 'object',
+      defaultValue: { width: '100%' }
     }
+  },
+  args: {
+    style: { width: '100%' }
   }
 } satisfies Meta<typeof ConversationsSource>;
 


### PR DESCRIPTION
我把 #353 的需求按现在的 v2 Conversations 重做了，原作者已经放进 co-author。

问题是 `style.width` 只传给了内部 `<ul>`，外层容器还是 `width: fit-content`，所以写 `style="width: 100%"` 也撑不开。现在会把同一个 width 通过 `--elx-conversations-container-width` 同步到外层：
- 字符串宽度原样使用
- number 自动转成 px
- 不传时保持原来的 280px 默认宽度

另外补了中英文 `style` 文档和 Storybook 控件。

我跑过：
- `pnpm build:core`

Closes #157
Closes #101
Closes #209

等这条合并后，#353 可以按已重做关闭。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the Conversations container width through the `style` property.
  - Numeric widths are automatically applied in pixels, while other CSS width values are supported.

- **Documentation**
  - Documented the optional `style` property in English and Chinese component guides.
  - Updated examples to show a default container width of 100%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->