### PR TITLE
fix(Thinking): content 为空时也能渲染插槽

### DIFF
--- a/packages/core/src/components/Thinking/index.vue
+++ b/packages/core/src/components/Thinking/index.vue
@@ -160,7 +160,7 @@ watch(
     <Transition :name="`${ns.b()}-slide`">
       <div
         v-show="isExpanded"
-        v-if="displayedContent"
+        v-if="displayedContent || $slots.content"
         :class="[
           ns.e('content-wrapper'),
           status === 'error' ? ns.em('content-wrapper', 'error-state') : ''


### PR DESCRIPTION
我看了下 #494，问题就是外层内容区只判断了 `displayedContent`，所以 `content=""` 时即使传了 `#content`，整个容器也不会创建。

现在改成“有文本或有 content 插槽”就渲染：
- 普通 content 行为不变
- error 状态行为不变
- 自定义 MarkdownRenderer 不需要再塞一个假的 content 值

我跑过：
- `pnpm build:core`

Closes #494