### PR TITLE
fix(Conversations, Attachments): 收口一批 v2 组件问题

### DIFF
--- a/apps/docs/en/components/conversations/index.md
+++ b/apps/docs/en/components/conversations/index.md
@@ -61,6 +61,7 @@ Override `Conversations` theme tokens via `ConfigProvider.themeOverrides`. See t
 | `showToTopBtn`         | `boolean`                     | No       | `false`   | Whether to show back to top button                                                       |
 | `labelKey`             | `string`                      | No       | `'label'` | Session item label field name                                                            |
 | `rowKey`               | `string`                      | No       | `'id'`    | Session item unique identifier field name                                                |
+| `style`                | `CSSProperties`               | No       | `{}`      | Container styles; use `width` to set the conversation list width                         |
 | `itemsStyle`           | `CSSProperties`               | No       | `{}`      | Session item default style                                                               |
 | `itemsHoverStyle`      | `CSSProperties`               | No       | `{}`      | Session item hover style                                                                 |
 | `itemsActiveStyle`     | `CSSProperties`               | No       | `{}`      | Session item active style                                                                |

--- a/apps/docs/en/components/conversations/index.md
+++ b/apps/docs/en/components/conversations/index.md
@@ -51,21 +51,22 @@ Override `Conversations` theme tokens via `ConfigProvider.themeOverrides`. See t
 
 ## Properties
 
-| Property Name          | Type                          | Required | Default   | Description                                                                              |
-| ---------------------- | ----------------------------- | -------- | --------- | ---------------------------------------------------------------------------------------- |
-| `items`                | `ConversationItem<T>[]`       | No       | `[]`      | Session item data list, containing `label`, `group`, `disabled` and other fields         |
-| `groupable`            | `boolean \| GroupableOptions` | No       | `false`   | Whether to enable grouping, passing object can customize group sorting (`sort` function) |
-| `showBuiltInMenu`      | `boolean`                     | No       | `false`   | Whether to show built-in menu (rename, delete)                                           |
-| `loadMore`             | `() => void`                  | No       | -         | Lazy loading callback function, triggered when scrolling to bottom                       |
-| `loadMoreLoading`      | `boolean`                     | No       | `false`   | Load more state, controls loading animation display                                      |
-| `showToTopBtn`         | `boolean`                     | No       | `false`   | Whether to show back to top button                                                       |
-| `labelKey`             | `string`                      | No       | `'label'` | Session item label field name                                                            |
-| `rowKey`               | `string`                      | No       | `'id'`    | Session item unique identifier field name                                                |
-| `style`                | `CSSProperties`               | No       | `{}`      | Container styles; use `width` to set the conversation list width                         |
-| `itemsStyle`           | `CSSProperties`               | No       | `{}`      | Session item default style                                                               |
-| `itemsHoverStyle`      | `CSSProperties`               | No       | `{}`      | Session item hover style                                                                 |
-| `itemsActiveStyle`     | `CSSProperties`               | No       | `{}`      | Session item active style                                                                |
-| `itemsMenuOpenedStyle` | `CSSProperties`               | No       | `{}`      | Session item style when menu is opened                                                   |
+| Property Name          | Type                          | Required | Default         | Description                                                                              |
+| ---------------------- | ----------------------------- | -------- | --------------- | ---------------------------------------------------------------------------------------- |
+| `items`                | `ConversationItem<T>[]`       | No       | `[]`            | Session item data list, containing `label`, `group`, `disabled` and other fields         |
+| `groupable`            | `boolean \| GroupableOptions` | No       | `false`         | Whether to enable grouping, passing object can customize group sorting (`sort` function) |
+| `showBuiltInMenu`      | `boolean`                     | No       | `false`         | Whether to show built-in menu (rename, delete)                                           |
+| `loadMore`             | `() => void`                  | No       | -               | Lazy loading callback function, triggered when scrolling to bottom                       |
+| `loadMoreLoading`      | `boolean`                     | No       | `false`         | Load more state, controls loading animation display                                      |
+| `loadMoreText`         | `string`                      | No       | `'加载更多...'` | Text displayed while loading more items                                                  |
+| `showToTopBtn`         | `boolean`                     | No       | `false`         | Whether to show back to top button                                                       |
+| `labelKey`             | `string`                      | No       | `'label'`       | Session item label field name                                                            |
+| `rowKey`               | `string`                      | No       | `'id'`          | Session item unique identifier field name                                                |
+| `style`                | `CSSProperties`               | No       | `{}`            | Container styles; use `width` to set the conversation list width                         |
+| `itemsStyle`           | `CSSProperties`               | No       | `{}`            | Session item default style                                                               |
+| `itemsHoverStyle`      | `CSSProperties`               | No       | `{}`            | Session item hover style                                                                 |
+| `itemsActiveStyle`     | `CSSProperties`               | No       | `{}`            | Session item active style                                                                |
+| `itemsMenuOpenedStyle` | `CSSProperties`               | No       | `{}`            | Session item style when menu is opened                                                   |
 
 ## Slots
 
@@ -75,6 +76,7 @@ Override `Conversations` theme tokens via `ConfigProvider.themeOverrides`. See t
 | `#label`       | `{ item: ConversationItem<T> }`                           | Custom session item label content, supports text overflow handling or rich text                                                                                                                            |
 | `#more-filled` | `{ item, isHovered, isActive, isMenuOpened, isDisabled }` | Session item right side additional content, displays status indicators (e.g.: disabled mark, action icons)                                                                                                 |
 | `#menu`        | `{ item: ConversationItem<T>, handleOpen, handleClose }`  | Custom menu content, supports buttons, icons or complex interactive components,`handleOpen`used to control the opening of the drop-down menu, `handleClose`used to control the closing of drop-down menus. |
+| `#load-more`   | `{ text: string }`                                        | Custom load-more area                                                                                                                                                                                      |
 | `#header`      | -                                                         | Container header slot, for adding search bars, filter buttons and other custom content                                                                                                                     |
 | `#footer`      | -                                                         | Container footer slot, for adding pagination, statistics and other custom content                                                                                                                          |
 

--- a/apps/docs/zh/components/conversations/index.md
+++ b/apps/docs/zh/components/conversations/index.md
@@ -51,21 +51,22 @@ title: 'Conversations'
 
 ## 属性
 
-| 属性名                 | 类型                          | 是否必填 | 默认值    | 描述                                                      |
-| ---------------------- | ----------------------------- | -------- | --------- | --------------------------------------------------------- |
-| `items`                | `ConversationItem<T>[]`       | 否       | `[]`      | 会话项数据列表，包含 `label`、`group`、`disabled` 等字段  |
-| `groupable`            | `boolean \| GroupableOptions` | 否       | `false`   | 是否启用分组功能，传入对象可自定义分组排序（`sort` 函数） |
-| `showBuiltInMenu`      | `boolean`                     | 否       | `false`   | 是否显示内置菜单（重命名、删除）                          |
-| `loadMore`             | `() => void`                  | 否       | -         | 懒加载回调函数，滚动至底部时触发                          |
-| `loadMoreLoading`      | `boolean`                     | 否       | `false`   | 加载更多状态，控制加载动画显示                            |
-| `showToTopBtn`         | `boolean`                     | 否       | `false`   | 是否显示返回顶部按钮                                      |
-| `labelKey`             | `string`                      | 否       | `'label'` | 会话项标签字段名                                          |
-| `rowKey`               | `string`                      | 否       | `'id'`    | 会话项唯一标识字段名                                      |
-| `style`                | `CSSProperties`               | 否       | `{}`      | 容器样式，可通过 `width` 设置会话列表宽度                 |
-| `itemsStyle`           | `CSSProperties`               | 否       | `{}`      | 会话项默认样式                                            |
-| `itemsHoverStyle`      | `CSSProperties`               | 否       | `{}`      | 会话项悬停样式                                            |
-| `itemsActiveStyle`     | `CSSProperties`               | 否       | `{}`      | 会话项激活样式                                            |
-| `itemsMenuOpenedStyle` | `CSSProperties`               | 否       | `{}`      | 会话项菜单打开时样式                                      |
+| 属性名                 | 类型                          | 是否必填 | 默认值          | 描述                                                      |
+| ---------------------- | ----------------------------- | -------- | --------------- | --------------------------------------------------------- |
+| `items`                | `ConversationItem<T>[]`       | 否       | `[]`            | 会话项数据列表，包含 `label`、`group`、`disabled` 等字段  |
+| `groupable`            | `boolean \| GroupableOptions` | 否       | `false`         | 是否启用分组功能，传入对象可自定义分组排序（`sort` 函数） |
+| `showBuiltInMenu`      | `boolean`                     | 否       | `false`         | 是否显示内置菜单（重命名、删除）                          |
+| `loadMore`             | `() => void`                  | 否       | -               | 懒加载回调函数，滚动至底部时触发                          |
+| `loadMoreLoading`      | `boolean`                     | 否       | `false`         | 加载更多状态，控制加载动画显示                            |
+| `loadMoreText`         | `string`                      | 否       | `'加载更多...'` | 加载更多状态的提示文案                                    |
+| `showToTopBtn`         | `boolean`                     | 否       | `false`         | 是否显示返回顶部按钮                                      |
+| `labelKey`             | `string`                      | 否       | `'label'`       | 会话项标签字段名                                          |
+| `rowKey`               | `string`                      | 否       | `'id'`          | 会话项唯一标识字段名                                      |
+| `style`                | `CSSProperties`               | 否       | `{}`            | 容器样式，可通过 `width` 设置会话列表宽度                 |
+| `itemsStyle`           | `CSSProperties`               | 否       | `{}`            | 会话项默认样式                                            |
+| `itemsHoverStyle`      | `CSSProperties`               | 否       | `{}`            | 会话项悬停样式                                            |
+| `itemsActiveStyle`     | `CSSProperties`               | 否       | `{}`            | 会话项激活样式                                            |
+| `itemsMenuOpenedStyle` | `CSSProperties`               | 否       | `{}`            | 会话项菜单打开时样式                                      |
 
 ## 插槽
 
@@ -75,6 +76,7 @@ title: 'Conversations'
 | `#label`       | `{ item: ConversationItem<T> }`                           | 自定义会话项标签内容，支持文本溢出处理或富文本                                                                               |
 | `#more-filled` | `{ item, isHovered, isActive, isMenuOpened, isDisabled }` | 会话项右侧附加内容，显示状态标识（如：禁用标记、操作图标）                                                                   |
 | `#menu`        | `{ item: ConversationItem<T>, handleOpen, handleClose }`  | 自定义菜单内容，支持按钮、图标或复杂交互组件,`handleOpen`用来手动控制下拉菜单的开启,`handleClose`用来手动控制下拉菜单的关闭. |
+| `#load-more`   | `{ text: string }`                                        | 自定义加载更多区域                                                                                                           |
 | `#header`      | -                                                         | 容器头部插槽，用于添加搜索栏、筛选按钮等自定义内容                                                                           |
 | `#footer`      | -                                                         | 容器底部插槽，用于添加分页、统计信息等自定义内容                                                                             |
 

--- a/apps/docs/zh/components/conversations/index.md
+++ b/apps/docs/zh/components/conversations/index.md
@@ -61,6 +61,7 @@ title: 'Conversations'
 | `showToTopBtn`         | `boolean`                     | 否       | `false`   | 是否显示返回顶部按钮                                      |
 | `labelKey`             | `string`                      | 否       | `'label'` | 会话项标签字段名                                          |
 | `rowKey`               | `string`                      | 否       | `'id'`    | 会话项唯一标识字段名                                      |
+| `style`                | `CSSProperties`               | 否       | `{}`      | 容器样式，可通过 `width` 设置会话列表宽度                 |
 | `itemsStyle`           | `CSSProperties`               | 否       | `{}`      | 会话项默认样式                                            |
 | `itemsHoverStyle`      | `CSSProperties`               | 否       | `{}`      | 会话项悬停样式                                            |
 | `itemsActiveStyle`     | `CSSProperties`               | 否       | `{}`      | 会话项激活样式                                            |

--- a/packages/core/src/components/Attachments/index.vue
+++ b/packages/core/src/components/Attachments/index.vue
@@ -278,20 +278,25 @@ defineExpose({
     }"
   >
     <div v-if="!items.length && !props.hideUpload">
-      <slot name="empty-upload">
-        <el-upload
-          class="elx-attachments-upload-btn"
-          v-bind="$attrs"
-          :show-file-list="false"
-          @change="handleUploadChange"
-          @success="handleUploadSuccess"
-          @error="handleUploadError"
-        >
-          <el-icon class="elx-attachments__uploader-icon">
-            <Plus />
-          </el-icon>
-        </el-upload>
-      </slot>
+      <el-upload
+        class="elx-attachments-upload-btn"
+        :class="{
+          'elx-attachments-upload-btn--custom': $slots['empty-upload']
+        }"
+        v-bind="$attrs"
+        :show-file-list="false"
+        @change="handleUploadChange"
+        @success="handleUploadSuccess"
+        @error="handleUploadError"
+      >
+        <template #trigger>
+          <slot name="empty-upload">
+            <el-icon class="elx-attachments__uploader-icon">
+              <Plus />
+            </el-icon>
+          </slot>
+        </template>
+      </el-upload>
     </div>
 
     <div class="elx-attachments-background">
@@ -349,25 +354,28 @@ defineExpose({
           v-if="items.length && !_isOverLimit && !props.hideUpload"
           class="elx-attachments-upload-placeholder"
         >
-          <slot name="no-empty-upload">
-            <el-upload
-              v-bind="$attrs"
-              :show-file-list="false"
-              :style="{
-                height: overflow === 'scrollY' && ''
-              }"
-              class="elx-attachments-upload-btn"
-              @change="handleUploadChange"
-              @success="handleUploadSuccess"
-              @error="handleUploadError"
-            >
-              <template #trigger>
+          <el-upload
+            v-bind="$attrs"
+            :show-file-list="false"
+            :style="{
+              height: overflow === 'scrollY' && ''
+            }"
+            class="elx-attachments-upload-btn"
+            :class="{
+              'elx-attachments-upload-btn--custom': $slots['no-empty-upload']
+            }"
+            @change="handleUploadChange"
+            @success="handleUploadSuccess"
+            @error="handleUploadError"
+          >
+            <template #trigger>
+              <slot name="no-empty-upload">
                 <el-icon class="elx-attachments__uploader-icon">
                   <Plus />
                 </el-icon>
-              </template>
-            </el-upload>
-          </slot>
+              </slot>
+            </template>
+          </el-upload>
         </div>
       </div>
     </div>

--- a/packages/core/src/components/Attachments/style.scss
+++ b/packages/core/src/components/Attachments/style.scss
@@ -138,6 +138,10 @@
 
 .elx-attachments-upload-btn {
   display: flex;
+
+  &--custom :deep(.el-upload) {
+    border: none;
+  }
 }
 
 :deep() {

--- a/packages/core/src/components/Attachments/style.scss
+++ b/packages/core/src/components/Attachments/style.scss
@@ -139,7 +139,7 @@
 .elx-attachments-upload-btn {
   display: flex;
 
-  &--custom :deep(.el-upload) {
+  &--custom {
     border: none;
   }
 }

--- a/packages/core/src/components/Attachments/style.scss
+++ b/packages/core/src/components/Attachments/style.scss
@@ -139,7 +139,7 @@
 .elx-attachments-upload-btn {
   display: flex;
 
-  &--custom {
+  &--custom.el-upload {
     border: none;
   }
 }

--- a/packages/core/src/components/Conversations/components/item.vue
+++ b/packages/core/src/components/Conversations/components/item.vue
@@ -314,6 +314,7 @@ function closeDropdown() {
               :content="item.label"
               :placement="tooltipPlacement"
               :offset="tooltipOffset"
+              :popper-class="ns.b('tooltip')"
               effect="dark"
             >
               <span

--- a/packages/core/src/components/Conversations/components/item.vue
+++ b/packages/core/src/components/Conversations/components/item.vue
@@ -122,6 +122,7 @@ function handleClick(key: string) {
 
 const labelRef = ref<HTMLElement | null>(null);
 const isTextOverflow = ref(false);
+let labelResizeObserver: ResizeObserver | null = null;
 
 async function updateTextOverflow() {
   if (!labelMaxWidth.value || !isClient) {
@@ -140,6 +141,29 @@ watch(
   updateTextOverflow,
   { deep: true, immediate: true }
 );
+
+watch(
+  labelRef,
+  label => {
+    labelResizeObserver?.disconnect();
+    labelResizeObserver = null;
+
+    if (!label || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    labelResizeObserver = new ResizeObserver(() => {
+      updateTextOverflow();
+    });
+    labelResizeObserver.observe(label);
+  },
+  { flush: 'post' }
+);
+
+onBeforeUnmount(() => {
+  labelResizeObserver?.disconnect();
+  labelResizeObserver = null;
+});
 
 // 计算标签样式
 const labelStyle = computed(() => {

--- a/packages/core/src/components/Conversations/components/item.vue
+++ b/packages/core/src/components/Conversations/components/item.vue
@@ -120,25 +120,26 @@ function handleClick(key: string) {
   emit('click', key);
 }
 
-const isTextOverflow = computed(() => {
-  // 如果没有设置labelMaxWidth，直接返回false
-  if (!labelMaxWidth.value || !isClient) return false;
+const labelRef = ref<HTMLElement | null>(null);
+const isTextOverflow = ref(false);
 
-  // 仅在 label 或 maxWidth 变化时测量一次，避免每次 render 重复操作 DOM
-  const span = document.createElement('span');
-  span.style.visibility = 'hidden';
-  span.style.position = 'absolute';
-  span.style.whiteSpace = 'nowrap';
-  span.style.fontSize = '14px'; // 与CSS中定义的字体大小一致
-  span.textContent = item.value.label ?? '';
+async function updateTextOverflow() {
+  if (!labelMaxWidth.value || !isClient) {
+    isTextOverflow.value = false;
+    return;
+  }
 
-  document.body.appendChild(span);
-  const textWidth = span.offsetWidth;
-  document.body.removeChild(span);
+  await nextTick();
+  const label = labelRef.value;
+  isTextOverflow.value =
+    label !== null && label.scrollWidth > label.clientWidth;
+}
 
-  // 如果文本宽度大于最大宽度，则返回true表示溢出
-  return textWidth > labelMaxWidth.value;
-});
+watch(
+  [() => item.value.label, labelMaxWidth, itemsStyle, labelRef],
+  updateTextOverflow,
+  { deep: true, immediate: true }
+);
 
 // 计算标签样式
 const labelStyle = computed(() => {
@@ -316,6 +317,7 @@ function closeDropdown() {
               effect="dark"
             >
               <span
+                ref="labelRef"
                 :class="[
                   ns.be('item', 'label'),
                   isTextOverflow ? ns.bem('item', 'label', 'gradient') : ''
@@ -326,6 +328,7 @@ function closeDropdown() {
             </ElTooltip>
             <span
               v-else
+              ref="labelRef"
               :class="[
                 ns.be('item', 'label'),
                 isTextOverflow ? ns.bem('item', 'label', 'gradient') : ''

--- a/packages/core/src/components/Conversations/components/item.vue
+++ b/packages/core/src/components/Conversations/components/item.vue
@@ -143,12 +143,12 @@ watch(
 );
 
 watch(
-  labelRef,
-  label => {
+  [labelRef, labelMaxWidth],
+  ([label, maxWidth]) => {
     labelResizeObserver?.disconnect();
     labelResizeObserver = null;
 
-    if (!label || typeof ResizeObserver === 'undefined') {
+    if (!label || !maxWidth || typeof ResizeObserver === 'undefined') {
       return;
     }
 

--- a/packages/core/src/components/Conversations/components/item.vue
+++ b/packages/core/src/components/Conversations/components/item.vue
@@ -121,25 +121,23 @@ function handleClick(key: string) {
 }
 
 const isTextOverflow = computed(() => {
-  return (label: string = '') => {
-    // 如果没有设置labelMaxWidth，直接返回false
-    if (!labelMaxWidth.value || !isClient) return false;
+  // 如果没有设置labelMaxWidth，直接返回false
+  if (!labelMaxWidth.value || !isClient) return false;
 
-    // 创建一个临时的span元素来测量文本宽度
-    const span = document.createElement('span');
-    span.style.visibility = 'hidden';
-    span.style.position = 'absolute';
-    span.style.whiteSpace = 'nowrap';
-    span.style.fontSize = '14px'; // 与CSS中定义的字体大小一致
-    span.textContent = label;
+  // 仅在 label 或 maxWidth 变化时测量一次，避免每次 render 重复操作 DOM
+  const span = document.createElement('span');
+  span.style.visibility = 'hidden';
+  span.style.position = 'absolute';
+  span.style.whiteSpace = 'nowrap';
+  span.style.fontSize = '14px'; // 与CSS中定义的字体大小一致
+  span.textContent = item.value.label ?? '';
 
-    document.body.appendChild(span);
-    const textWidth = span.offsetWidth;
-    document.body.removeChild(span);
+  document.body.appendChild(span);
+  const textWidth = span.offsetWidth;
+  document.body.removeChild(span);
 
-    // 如果文本宽度大于最大宽度，则返回true表示溢出
-    return textWidth > labelMaxWidth.value;
-  };
+  // 如果文本宽度大于最大宽度，则返回true表示溢出
+  return textWidth > labelMaxWidth.value;
 });
 
 // 计算标签样式
@@ -310,7 +308,7 @@ function closeDropdown() {
           <!-- 标签和时间戳 -->
           <div :class="ns.be('item', 'label-container')">
             <ElTooltip
-              v-if="showTooltip && isTextOverflow(item.label)"
+              v-if="showTooltip && isTextOverflow"
               :content="item.label"
               :placement="tooltipPlacement"
               :offset="tooltipOffset"
@@ -320,9 +318,7 @@ function closeDropdown() {
               <span
                 :class="[
                   ns.be('item', 'label'),
-                  isTextOverflow(item.label)
-                    ? ns.bem('item', 'label', 'gradient')
-                    : ''
+                  isTextOverflow ? ns.bem('item', 'label', 'gradient') : ''
                 ]"
                 :style="labelStyle"
                 >{{ item.label }}</span
@@ -332,9 +328,7 @@ function closeDropdown() {
               v-else
               :class="[
                 ns.be('item', 'label'),
-                isTextOverflow(item.label)
-                  ? ns.bem('item', 'label', 'gradient')
-                  : ''
+                isTextOverflow ? ns.bem('item', 'label', 'gradient') : ''
               ]"
               :style="labelStyle"
               >{{ item.label }}</span

--- a/packages/core/src/components/Conversations/index.vue
+++ b/packages/core/src/components/Conversations/index.vue
@@ -121,6 +121,11 @@ const mergedStyle = computed(() => {
   };
 });
 
+const listStyle = computed(() => ({
+  ...mergedStyle.value,
+  width: undefined
+}));
+
 const containerStyle = computed(() => {
   const width = mergedStyle.value.width;
   return ns.cssVarBlock({
@@ -389,7 +394,7 @@ onMounted(() => {
 <template>
   <div :class="ns.b()" :style="containerStyle">
     <slot name="header" />
-    <ul :class="ns.e('list')" :style="mergedStyle">
+    <ul :class="ns.e('list')" :style="listStyle">
       <!-- 滚动区域容器 -->
       <li :class="ns.e('scroll-wrapper')">
         <el-scrollbar

--- a/packages/core/src/components/Conversations/index.vue
+++ b/packages/core/src/components/Conversations/index.vue
@@ -61,6 +61,7 @@ const props = withDefaults(defineProps<Conversation<T>>(), {
   menuTeleported: true,
   menuStyle: () => ({}),
   loadMoreLoading: false,
+  loadMoreText: '加载更多...',
   showToTopBtn: false,
   labelKey: 'label',
   rowKey: 'id'
@@ -533,11 +534,11 @@ onMounted(() => {
 
           <!-- 加载更多 -->
           <div v-if="props.loadMoreLoading" :class="ns.e('load-more')">
-            <slot name="load-more">
+            <slot name="load-more" :text="props.loadMoreText">
               <el-icon :class="ns.e('load-more-icon')">
                 <Loading />
               </el-icon>
-              <span>加载更多...</span>
+              <span>{{ props.loadMoreText }}</span>
             </slot>
           </div>
         </el-scrollbar>

--- a/packages/core/src/components/Conversations/index.vue
+++ b/packages/core/src/components/Conversations/index.vue
@@ -117,7 +117,9 @@ const mergedStyle = computed(() => {
 });
 
 const containerStyle = computed(() => {
+  const width = mergedStyle.value.width;
   return ns.cssVarBlock({
+    'container-width': typeof width === 'number' ? `${width}px` : width,
     'label-height': `${props.labelHeight}px`,
     'list-auto-bg-color': mergedStyle.value.backgroundColor as string
   });

--- a/packages/core/src/components/Conversations/index.vue
+++ b/packages/core/src/components/Conversations/index.vue
@@ -113,7 +113,11 @@ const mergedStyle = computed(() => {
     width: '280px',
     height: '0'
   };
-  return { ...defaultStyle, ...props.style };
+  return {
+    ...defaultStyle,
+    ...props.style,
+    width: props.style?.width ?? defaultStyle.width
+  };
 });
 
 const containerStyle = computed(() => {

--- a/packages/core/src/components/Conversations/style.scss
+++ b/packages/core/src/components/Conversations/style.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   height: 100%;
   position: relative;
-  width: fit-content;
+  width: var(--elx-conversations-container-width, fit-content);
   box-sizing: border-box;
   overflow: hidden;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);

--- a/packages/core/src/components/Conversations/types.d.ts
+++ b/packages/core/src/components/Conversations/types.d.ts
@@ -86,6 +86,7 @@ export interface Conversation<T extends AnyObject = AnyObject> {
   menuTeleported?: boolean;
   loadMore?: () => void;
   loadMoreLoading?: boolean;
+  loadMoreText?: string;
   showToTopBtn?: boolean;
   rowKey?: keyof T;
   labelKey?: keyof T;

--- a/packages/core/src/stories/Conversations/Conversations.stories.ts
+++ b/packages/core/src/stories/Conversations/Conversations.stories.ts
@@ -65,7 +65,15 @@ const meta: Meta<typeof ConversationsSource> = {
       description: '会话项菜单打开时样式',
       control: 'object',
       defaultValue: {}
+    },
+    style: {
+      description: '会话列表容器样式',
+      control: 'object',
+      defaultValue: { width: '100%' }
     }
+  },
+  args: {
+    style: { width: '100%' }
   }
 } satisfies Meta<typeof ConversationsSource>;
 

--- a/packages/core/src/stories/Conversations/Conversations.stories.ts
+++ b/packages/core/src/stories/Conversations/Conversations.stories.ts
@@ -31,6 +31,11 @@ const meta: Meta<typeof ConversationsSource> = {
       control: 'boolean',
       defaultValue: false
     },
+    loadMoreText: {
+      description: '加载更多状态的提示文案',
+      control: 'text',
+      defaultValue: '加载更多...'
+    },
     showToTopBtn: {
       description: '是否显示返回顶部按钮',
       control: 'boolean',


### PR DESCRIPTION
按当前讨论，这条合并原 #507、#510、#512，集中 review 和合并。原作者/co-author 信息保留在 commit 中。

包含：
- Conversations 宽度：`style.width` 同步到外层容器，number 转 px，null/undefined 保持默认 280px；补中英文文档和 Storybook 控件
- Attachments：`empty-upload` / `no-empty-upload` 放回 ElUpload trigger，自定义内容可以唤起文件选择
- Conversations 懒加载：新增 `loadMoreText`，`#load-more` 插槽补 `text` 参数
- Conversations Tooltip：增加稳定类名 `elx-conversations-tooltip`
- Conversations Tooltip 性能：溢出宽度按 `item.label + labelMaxWidth` 缓存，避免每次 render 重复创建和挂载 span

合并时已解决 Conversations 中英文 API 表冲突，同时保留 `style` 和 `loadMoreText`。

验证：
- `pnpm build:core`

Closes #157
Closes #101
Closes #209
Closes #130
Closes #483
Closes #415
Closes #446

#300 是完整 i18n，Thinking、BubbleList、FilesCard 等内置文案还没统一处理，所以不会由这条关闭。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable conversation container width styling.
  - Added customizable “load more” text and a slot for tailoring the loading area.
  - Improved attachment upload controls with custom trigger support.

- **Bug Fixes**
  - Improved conversation label overflow detection and tooltip behavior.
  - Preserved the default container width when custom styling is incomplete.

- **Documentation**
  - Updated English and Chinese Conversations documentation with styling and loading customization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->