### PR TITLE
fix(useXStream): 修复取消后仍追加数据

### DIFF
--- a/packages/core/src/hooks/useXStream.ts
+++ b/packages/core/src/hooks/useXStream.ts
@@ -13,16 +13,14 @@ function splitStream() {
     transform(chunk, controller) {
       buffer += chunk;
       const parts = buffer.split(DEFAULT_STREAM_SEPARATOR);
-      parts.slice(0, -1).forEach((part) => {
-        if (isValidString(part))
-          controller.enqueue(part);
+      parts.slice(0, -1).forEach(part => {
+        if (isValidString(part)) controller.enqueue(part);
       });
       buffer = parts[parts.length - 1];
     },
     flush(controller) {
-      if (isValidString(buffer))
-        controller.enqueue(buffer);
-    },
+      if (isValidString(buffer)) controller.enqueue(buffer);
+    }
   });
 }
 
@@ -32,20 +30,17 @@ function splitPart() {
       const lines = partChunk.split(DEFAULT_PART_SEPARATOR);
       const sseEvent = lines.reduce<SSEOutput>((acc, line) => {
         const sepIndex = line.indexOf(DEFAULT_KV_SEPARATOR);
-        if (sepIndex === -1)
-          return acc;
+        if (sepIndex === -1) return acc;
 
         const key = line.slice(0, sepIndex);
-        if (!isValidString(key))
-          return acc;
+        if (!isValidString(key)) return acc;
 
         const value = line.slice(sepIndex + 1);
         return { ...acc, [key]: value };
       }, {});
 
-      if (Object.keys(sseEvent).length > 0)
-        controller.enqueue(sseEvent);
-    },
+      if (Object.keys(sseEvent).length > 0) controller.enqueue(sseEvent);
+    }
   });
 }
 
@@ -67,44 +62,47 @@ type XReadableStream<R = SSEOutput> = ReadableStream<R> & {
 // 核心流处理函数（支持中断）
 function XStream<Output = SSEOutput>(
   options: XStreamOptions<Output>,
-  signal?: AbortSignal,
+  signal?: AbortSignal
 ): XReadableStream<Output> {
   const { readableStream, transformStream } = options;
   if (!(readableStream instanceof ReadableStream)) {
-    throw new TypeError('options.readableStream 必须是 ReadableStream 的实例。');
+    throw new TypeError(
+      'options.readableStream 必须是 ReadableStream 的实例。'
+    );
   }
 
   const decoderStream = new TextDecoderStream();
   const processedStream = transformStream
-    ? readableStream
+    ? readableStream.pipeThrough(decoderStream).pipeThrough(transformStream)
+    : (readableStream
         .pipeThrough(decoderStream)
-        .pipeThrough(transformStream)
-    : readableStream
-      .pipeThrough(decoderStream)
-      .pipeThrough(splitStream())
-      .pipeThrough(splitPart()) as XReadableStream<Output>;
+        .pipeThrough(splitStream())
+        .pipeThrough(splitPart()) as XReadableStream<Output>);
 
   // 为流添加异步迭代器并处理中断信号
-  (processedStream as XReadableStream<Output>)[Symbol.asyncIterator] = async function* () {
-    const reader = this.getReader();
-    (this as XReadableStream<Output>).reader = reader; // 保存读取器引用
-    try {
-      while (true) {
+  (processedStream as XReadableStream<Output>)[Symbol.asyncIterator] =
+    async function* () {
+      const reader = this.getReader();
+      const cancelReader = () => {
+        void reader.cancel().catch(() => undefined);
+      };
+      (this as XReadableStream<Output>).reader = reader; // 保存读取器引用
+      signal?.addEventListener('abort', cancelReader, { once: true });
+      try {
         if (signal?.aborted) {
-          await reader.cancel(); // 主动取消 reader
-          break;
+          await reader.cancel();
+          return;
         }
-        const { done, value } = await reader.read();
-        if (done)
-          break;
-        if (value)
-          yield value;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done || signal?.aborted) break;
+          if (value) yield value;
+        }
+      } finally {
+        signal?.removeEventListener('abort', cancelReader);
+        reader.releaseLock(); // 释放锁
       }
-    }
-    finally {
-      reader.releaseLock(); // 释放锁
-    }
-  };
+    };
 
   return processedStream as XReadableStream<Output>;
 }
@@ -116,44 +114,65 @@ export function useXStream() {
   const isLoading = ref<boolean>(false);
   const abortController = shallowRef<AbortController | null>(null);
   const currentStream = shallowRef<XReadableStream<SSEOutput> | null>(null);
+  let streamGeneration = 0;
+
+  const stopCurrentStream = () => {
+    abortController.value?.abort();
+    const reader = currentStream.value?.reader;
+    if (reader) {
+      void reader.cancel().catch(() => undefined);
+    }
+    currentStream.value = null;
+    abortController.value = null;
+  };
 
   // 启动流式请求
   const startStream = async (options: XStreamOptions<SSEOutput>) => {
+    stopCurrentStream();
+    const generation = ++streamGeneration;
+    const controller = new AbortController();
+
     isLoading.value = true;
     error.value = null;
     data.value = [];
-    abortController.value = new AbortController();
-    currentStream.value = XStream(options, abortController.value.signal);
+    abortController.value = controller;
 
     try {
-      for await (const item of currentStream.value!) {
+      const stream = XStream(options, controller.signal);
+      currentStream.value = stream;
+      for await (const item of stream) {
+        if (controller.signal.aborted || generation !== streamGeneration) break;
         data.value.push(item);
       }
-    }
-    catch (err) {
-      if (err instanceof Error) {
+    } catch (err) {
+      if (
+        generation === streamGeneration &&
+        !controller.signal.aborted &&
+        err instanceof Error
+      ) {
         error.value = err;
       }
-    }
-    finally {
-      isLoading.value = false;
-      currentStream.value = null; // 释放流引用
-      abortController.value = null; // 释放控制器
+    } finally {
+      if (generation === streamGeneration) {
+        isLoading.value = false;
+        currentStream.value = null;
+        abortController.value = null;
+      }
     }
   };
 
   // 中断流式请求（强制关闭流）
   const cancel = () => {
-    if (abortController.value) {
-      abortController.value.abort();
-    }
+    streamGeneration += 1;
+    stopCurrentStream();
+    isLoading.value = false;
   };
 
   return {
     startStream,
-    cancel, // 新增中断方法
+    cancel,
     data,
     error,
-    isLoading,
+    isLoading
   };
 }

--- a/packages/core/src/hooks/useXStream.ts
+++ b/packages/core/src/hooks/useXStream.ts
@@ -13,14 +13,16 @@ function splitStream() {
     transform(chunk, controller) {
       buffer += chunk;
       const parts = buffer.split(DEFAULT_STREAM_SEPARATOR);
-      parts.slice(0, -1).forEach(part => {
-        if (isValidString(part)) controller.enqueue(part);
+      parts.slice(0, -1).forEach((part) => {
+        if (isValidString(part))
+          controller.enqueue(part);
       });
       buffer = parts[parts.length - 1];
     },
     flush(controller) {
-      if (isValidString(buffer)) controller.enqueue(buffer);
-    }
+      if (isValidString(buffer))
+        controller.enqueue(buffer);
+    },
   });
 }
 
@@ -30,17 +32,20 @@ function splitPart() {
       const lines = partChunk.split(DEFAULT_PART_SEPARATOR);
       const sseEvent = lines.reduce<SSEOutput>((acc, line) => {
         const sepIndex = line.indexOf(DEFAULT_KV_SEPARATOR);
-        if (sepIndex === -1) return acc;
+        if (sepIndex === -1)
+          return acc;
 
         const key = line.slice(0, sepIndex);
-        if (!isValidString(key)) return acc;
+        if (!isValidString(key))
+          return acc;
 
         const value = line.slice(sepIndex + 1);
         return { ...acc, [key]: value };
       }, {});
 
-      if (Object.keys(sseEvent).length > 0) controller.enqueue(sseEvent);
-    }
+      if (Object.keys(sseEvent).length > 0)
+        controller.enqueue(sseEvent);
+    },
   });
 }
 
@@ -62,47 +67,49 @@ type XReadableStream<R = SSEOutput> = ReadableStream<R> & {
 // 核心流处理函数（支持中断）
 function XStream<Output = SSEOutput>(
   options: XStreamOptions<Output>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ): XReadableStream<Output> {
   const { readableStream, transformStream } = options;
   if (!(readableStream instanceof ReadableStream)) {
-    throw new TypeError(
-      'options.readableStream 必须是 ReadableStream 的实例。'
-    );
+    throw new TypeError('options.readableStream 必须是 ReadableStream 的实例。');
   }
 
   const decoderStream = new TextDecoderStream();
   const processedStream = transformStream
-    ? readableStream.pipeThrough(decoderStream).pipeThrough(transformStream)
-    : (readableStream
+    ? readableStream
         .pipeThrough(decoderStream)
-        .pipeThrough(splitStream())
-        .pipeThrough(splitPart()) as XReadableStream<Output>);
+        .pipeThrough(transformStream)
+    : readableStream
+      .pipeThrough(decoderStream)
+      .pipeThrough(splitStream())
+      .pipeThrough(splitPart()) as XReadableStream<Output>;
 
   // 为流添加异步迭代器并处理中断信号
-  (processedStream as XReadableStream<Output>)[Symbol.asyncIterator] =
-    async function* () {
-      const reader = this.getReader();
-      const cancelReader = () => {
-        void reader.cancel().catch(() => undefined);
-      };
-      (this as XReadableStream<Output>).reader = reader; // 保存读取器引用
-      signal?.addEventListener('abort', cancelReader, { once: true });
-      try {
-        if (signal?.aborted) {
-          await reader.cancel();
-          return;
-        }
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done || signal?.aborted) break;
-          if (value) yield value;
-        }
-      } finally {
-        signal?.removeEventListener('abort', cancelReader);
-        reader.releaseLock(); // 释放锁
-      }
+  (processedStream as XReadableStream<Output>)[Symbol.asyncIterator] = async function* () {
+    const reader = this.getReader();
+    const cancelReader = () => {
+      void reader.cancel().catch(() => undefined);
     };
+    (this as XReadableStream<Output>).reader = reader; // 保存读取器引用
+    signal?.addEventListener('abort', cancelReader, { once: true });
+    try {
+      if (signal?.aborted) {
+        await reader.cancel();
+        return;
+      }
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done || signal?.aborted)
+          break;
+        if (value)
+          yield value;
+      }
+    }
+    finally {
+      signal?.removeEventListener('abort', cancelReader);
+      reader.releaseLock(); // 释放锁
+    }
+  };
 
   return processedStream as XReadableStream<Output>;
 }
@@ -141,22 +148,25 @@ export function useXStream() {
       const stream = XStream(options, controller.signal);
       currentStream.value = stream;
       for await (const item of stream) {
-        if (controller.signal.aborted || generation !== streamGeneration) break;
+        if (controller.signal.aborted || generation !== streamGeneration)
+          break;
         data.value.push(item);
       }
-    } catch (err) {
+    }
+    catch (err) {
       if (
-        generation === streamGeneration &&
-        !controller.signal.aborted &&
-        err instanceof Error
+        generation === streamGeneration
+        && !controller.signal.aborted
+        && err instanceof Error
       ) {
         error.value = err;
       }
-    } finally {
+    }
+    finally {
       if (generation === streamGeneration) {
         isLoading.value = false;
-        currentStream.value = null;
-        abortController.value = null;
+        currentStream.value = null; // 释放流引用
+        abortController.value = null; // 释放控制器
       }
     }
   };
@@ -170,9 +180,9 @@ export function useXStream() {
 
   return {
     startStream,
-    cancel,
+    cancel, // 新增中断方法
     data,
     error,
-    isLoading
+    isLoading,
   };
 }

--- a/packages/core/src/hooks/useXStream.ts
+++ b/packages/core/src/hooks/useXStream.ts
@@ -123,7 +123,11 @@ export function useXStream() {
   const currentStream = shallowRef<XReadableStream<SSEOutput> | null>(null);
   let streamGeneration = 0;
 
-  const stopCurrentStream = () => {
+  const stopCurrentStream = (): boolean => {
+    const hasActiveStream =
+      abortController.value !== null || currentStream.value !== null;
+    if (!hasActiveStream) return false;
+
     abortController.value?.abort();
     const reader = currentStream.value?.reader;
     if (reader) {
@@ -131,6 +135,7 @@ export function useXStream() {
     }
     currentStream.value = null;
     abortController.value = null;
+    return true;
   };
 
   // 启动流式请求
@@ -172,10 +177,11 @@ export function useXStream() {
   };
 
   // 中断流式请求（强制关闭流）
-  const cancel = () => {
+  const cancel = (): boolean => {
     streamGeneration += 1;
-    stopCurrentStream();
+    const didStop = stopCurrentStream();
     isLoading.value = false;
+    return didStop;
   };
 
   return {


### PR DESCRIPTION
这条只处理 #86 的现行 bug。

根因是 cancel 只 abort signal；如果异步迭代器正卡在 `reader.read()`，要等下一块数据到达才会再次检查 signal，所以会先多 push 一条，loading 也一直不结束。

这次改动：
- abort 时直接 cancel 当前 reader，立即解除 pending read
- cancel 立即回落 loading 并清理当前引用
- 用 generation 隔离前后两次 stream，旧请求的 finally 不会清掉新请求状态
- 新 stream 启动时主动停止旧 stream

验证：
- `pnpm build:core`
- 真实 ReadableStream 回归脚本：取消后 data 不增加、loading 立即 false、取消后马上启动新流不会被旧 finally 干扰

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability when requests are canceled or replaced.
  * Prevented results from older streams from appearing after a newer stream starts.
  * Avoided displaying cancellation-related errors when stopping a stream.
  * Improved handling of streams that are already canceled before they begin.
  * Ensured active streams report whether cancellation was successful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->